### PR TITLE
Add --debug option to trace HTTP requests

### DIFF
--- a/cloud/clientset.go
+++ b/cloud/clientset.go
@@ -27,6 +27,8 @@ type Config struct {
 	// Optional
 	APIBaseURL       string
 	ProvisionBaseURL string
+
+	DebugEnabled bool
 }
 
 // API returns an instance of the API client
@@ -43,16 +45,18 @@ func (c *Clientset) Provision() provision.Interface {
 // If base URLs are not provided, they will be defaulted by the underlying clients
 func New(cfg Config) (*Clientset, error) {
 	api, err := api.New(rest.Config{
-		BaseURL: cfg.APIBaseURL,
-		Token:   cfg.Token,
+		BaseURL:      cfg.APIBaseURL,
+		Token:        cfg.Token,
+		DebugEnabled: cfg.DebugEnabled,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing API client")
 	}
 
 	provision, err := provision.New(rest.Config{
-		BaseURL: cfg.ProvisionBaseURL,
-		Token:   cfg.Token,
+		BaseURL:      cfg.ProvisionBaseURL,
+		Token:        cfg.Token,
+		DebugEnabled: cfg.DebugEnabled,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing provision client")

--- a/cloud/rest/client.go
+++ b/cloud/rest/client.go
@@ -18,14 +18,16 @@ type Interface interface {
 
 // Client is a basic HTTP client for REST operations
 type Client struct {
-	baseURL *url.URL
-	token   string
+	baseURL      *url.URL
+	token        string
+	debugEnabled bool
 }
 
 // Config is the configuration for a REST client
 type Config struct {
-	BaseURL string
-	Token   string
+	BaseURL      string
+	Token        string
+	DebugEnabled bool
 }
 
 // NewClient constructs a new REST client for the given config
@@ -42,8 +44,9 @@ func NewClient(cfg Config) (*Client, error) {
 	}
 
 	return &Client{
-		baseURL: baseURL,
-		token:   cfg.Token,
+		baseURL:      baseURL,
+		token:        cfg.Token,
+		debugEnabled: cfg.DebugEnabled,
 	}, nil
 }
 
@@ -78,7 +81,7 @@ func (c *Client) execute(verb string, path string, body interface{}, output inte
 
 	authHeader := fmt.Sprintf("JWT %s", c.token)
 
-	req := resty.R().SetHeader("Authorization", authHeader)
+	req := resty.SetDebug(c.debugEnabled).R().SetHeader("Authorization", authHeader)
 
 	if body != nil {
 		req.SetBody(body)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,8 @@ import (
 
 // Flags / config options
 var (
-	cfgFile string
+	cfgFile      string
+	debugEnabled bool
 
 	// TODO support names, not just IDs, and resolve appropriately
 	organizationID string
@@ -125,6 +126,7 @@ This is a long description`,
 			Token:            userToken,
 			APIBaseURL:       viper.GetString("apiBaseURL"),
 			ProvisionBaseURL: viper.GetString("provisionBaseURL"),
+			DebugEnabled:     debugEnabled,
 		})
 
 		return err
@@ -146,6 +148,8 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is ~/.containership/csctl.yaml)")
+
+	rootCmd.PersistentFlags().BoolVar(&debugEnabled, "debug", false, "enable/disable debug mode (trace all HTTP requests)")
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
### Description

 #### What does this pull request accomplish?

Add `--debug` option to trace HTTP requests

Note that this is distinct from https://github.com/containership/csctl/issues/38 and is likely just an interim thing. I've found it useful in the meantime, so I'm PRing it for others :)

 #### What issue(s) does this fix?
* None

 #### Additional Considerations

 ### Testing

 #### Setup

 `make install`

 #### Instructions

 - `csctl get users --debug` to hit API service dumps debug info
 - `csctl get clusters --debug` to hit provision service dumps debug info

 ### Dependencies
* None