### PR TITLE
Add credentials key to registry response

### DIFF
--- a/cloud/api/swagger.yaml
+++ b/cloud/api/swagger.yaml
@@ -781,6 +781,9 @@ definitions:
       updated_at:
         title: Timestamp at which the registry was updated
         type: string
+      credentials:
+        title: Registry credentials
+        type:  object
 
   Registries:
     type: array

--- a/cloud/api/types/registry.go
+++ b/cloud/api/types/registry.go
@@ -21,6 +21,9 @@ type Registry struct {
 	// Required: true
 	CreatedAt *string `json:"created_at"`
 
+	// Registry credentials
+	Credentials interface{} `json:"credentials,omitempty"`
+
 	// Registry description
 	// Required: true
 	Description *string `json:"description"`


### PR DESCRIPTION
 ### Description

Adds credentials to the registry response if the token is a cluster token. 

This is needed for https://github.com/containership/cluster-manager/issues/4

 #### What does this pull request accomplish?

 #### What issue(s) does this fix?

 #### Additional Considerations

 ### Testing

 #### Setup

 #### Instructions

 ### Dependencies
