### PR TITLE
Add support for template creation from a file

### DIFF
--- a/cmd/create_template.go
+++ b/cmd/create_template.go
@@ -1,8 +1,15 @@
 package cmd
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/containership/csctl/cloud/provision/types"
+	"github.com/containership/csctl/resource"
 	"github.com/containership/csctl/resource/options"
 )
 
@@ -12,15 +19,55 @@ var createTemplateOpts options.TemplateCreate
 var createTemplateCmd = &cobra.Command{
 	Use:   "template",
 	Short: "Create a cluster template for provisioning",
+	Long: `Create a template for provisioning
+
+If creating a template from a file, do not specify a provider to use and instead simply run:
+
+csctl create template -f <filename>
+
+This file must be json (TODO support yaml). All other template-specific flags will be ignored if -f is used.
+
+Otherwise, please use a provider subcommand to create a template with more advanced, provider-specific flags.`,
 
 	// TODO using PersistentPreRunE here to org-scope all create template
 	// subcommands would be nice, but it won't work currently because the
 	// root command is already using it and this cobra issue is open:
 	// https://github.com/spf13/cobra/issues/252
+	PreRunE: orgScopedPreRunE,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		f, err := os.Open(filename)
+		if err != nil {
+			return errors.Wrap(err, "opening file")
+		}
+		defer f.Close()
+
+		bytes, err := ioutil.ReadAll(f)
+		if err != nil {
+			return errors.Wrap(err, "reading file")
+		}
+
+		var req types.CreateTemplateRequest
+
+		err = json.Unmarshal(bytes, &req)
+		if err != nil {
+			return errors.Wrap(err, "unmarshalling file into request type")
+		}
+
+		template, err := clientset.Provision().Templates(organizationID).Create(&req)
+		if err != nil {
+			return err
+		}
+
+		t := resource.NewTemplates([]types.Template{*template})
+		return t.Table(os.Stdout)
+	},
 }
 
 func init() {
 	createCmd.AddCommand(createTemplateCmd)
+
+	createTemplateCmd.Flags().StringVarP(&filename, "filename", "f", "", "create a template from the given file (TODO must be json for now)")
 
 	// No defaulting is performed here because the logic in many cases is nontrivial,
 	// and we'd like to be consistent with where and how we default.


### PR DESCRIPTION
### Description

 #### What does this pull request accomplish?

 This is a quick little feature in order to make creating a bunch of templates for integration testing easier for now.
 It enables the following workflow:

 ```
 csctl get template <id> -ojson > template.json`
 # modify template.json
 csctl create template -f template.json
 ```

 Ideally, in the future, this create-from-file flow would be a lot more generic.

 #### What issue(s) does this fix?
* No issue

 #### Additional Considerations

 ### Testing

 #### Setup

 N/A

 #### Instructions

```
cat template.json
```
```
{
  "configuration": {
    "resource": {
      "digitalocean_droplet": {
        "np0": {
          "image": "ubuntu-16-04-x64",
          "private_networking": true,
          "region": "nyc3",
          "size": "s-1vcpu-2gb"
        },
        "np1": {
          "image": "ubuntu-16-04-x64",
          "private_networking": true,
          "region": "nyc3",
          "size": "s-1vcpu-2gb"
        }
      }
    },
    "variable": {
      "np0": {
        "default": {
          "count": 3,
          "kubernetes_mode": "worker",
          "kubernetes_version": "1.11.5",
          "name": "worker-pool-1",
          "type": "node_pool"
        }
      },
      "np1": {
        "default": {
          "count": 3,
          "etcd": true,
          "kubernetes_mode": "master",
          "kubernetes_version": "1.11.5",
          "name": "master-pool-1",
          "type": "node_pool"
        }
      }
    }
  },
  "created_at": "1546618852250",
  "description": "--",
  "engine": "containership_kubernetes_engine",
  "id": "53044aa4-9028-4f3e-befb-3406f4c83378",
  "organization_id": "62e4e86f-fe2e-4740-a814-a950bf377daf",
  "owner_id": "102547e8-5c50-4a8c-ae4a-afc5ee863580",
  "provider_name": "digital_ocean",
  "updated_at": "1546618852250"
}
```

```
go run main.go create template -f template.json
```
```
ID                                      DESCRIPTION     PROVIDER_NAME   MASTER_VERSION  OWNER_ID                                CREATED_AT
439eddc9-3d26-44e2-b574-09a630afca36    --              digital_ocean   1.11.5          576eb5eb-26df-47af-8abc-f4effcd59ec1    2019-02-14 12:53:09 -0500 EST
```

 ### Dependencies
* None