### PR TITLE
fix output to shift the json list if getting a single resource #88

### DIFF
--- a/cmd/get_access_token.go
+++ b/cmd/get_access_token.go
@@ -32,6 +32,10 @@ var getAccessTokenCmd = &cobra.Command{
 
 		tokens := resource.NewAccessTokens(resp)
 
+		if len(args) == 1 {
+			resource.AccessToken().DisableListView()
+		}
+
 		outputResponse(tokens)
 		return nil
 	},

--- a/cmd/get_account.go
+++ b/cmd/get_account.go
@@ -24,6 +24,10 @@ var getAccountCmd = &cobra.Command{
 
 		accounts := resource.NewAccounts(resp)
 
+		if len(args) == 1 {
+			resource.Account().DisableListView()
+		}
+
 		outputResponse(accounts)
 		return nil
 	},

--- a/cmd/get_autoscaling_policy.go
+++ b/cmd/get_autoscaling_policy.go
@@ -46,6 +46,11 @@ var getAutoscalingPolicyCmd = &cobra.Command{
 		}
 
 		nps := resource.NewAutoscalingPolicies(resp)
+
+		if len(args) == 1 {
+			resource.AutoscalingPolicy().DisableListView()
+		}
+
 		outputResponse(nps)
 
 		return nil

--- a/cmd/get_cluster.go
+++ b/cmd/get_cluster.go
@@ -35,7 +35,7 @@ var getClusterCmd = &cobra.Command{
 		clusters := resource.NewCKEClusters(resp)
 
 		if len(args) == 1 {
-			clusters.DisableItemListView()
+			resource.CKECluster().DisableListView()
 		}
 
 		if mineOnly {

--- a/cmd/get_cluster.go
+++ b/cmd/get_cluster.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"github.com/spf13/cobra"
+
 	provisiontypes "github.com/containership/csctl/cloud/provision/types"
 	"github.com/containership/csctl/resource"
-	"github.com/spf13/cobra"
 )
 
 // getClusterCmd represents the getCluster command

--- a/cmd/get_cluster.go
+++ b/cmd/get_cluster.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-
 	provisiontypes "github.com/containership/csctl/cloud/provision/types"
 	"github.com/containership/csctl/resource"
+	"github.com/spf13/cobra"
 )
 
 // getClusterCmd represents the getCluster command
@@ -33,6 +32,10 @@ var getClusterCmd = &cobra.Command{
 		}
 
 		clusters := resource.NewCKEClusters(resp)
+
+		if len(args) == 1 {
+			clusters.DisableItemListView()
+		}
 
 		if mineOnly {
 			me, err := getMyAccountID()

--- a/cmd/get_node.go
+++ b/cmd/get_node.go
@@ -33,6 +33,11 @@ var getNodeCmd = &cobra.Command{
 		}
 
 		nps := resource.NewNodes(resp)
+
+		if len(args) == 1 {
+			resource.Node().DisableListView()
+		}
+
 		outputResponse(nps)
 
 		return nil

--- a/cmd/get_node_pool.go
+++ b/cmd/get_node_pool.go
@@ -33,6 +33,11 @@ var getNodePoolCmd = &cobra.Command{
 		}
 
 		nps := resource.NewNodePools(resp)
+
+		if len(args) == 1 {
+			resource.NodePool().DisableListView()
+		}
+
 		outputResponse(nps)
 
 		return nil

--- a/cmd/get_organization.go
+++ b/cmd/get_organization.go
@@ -32,6 +32,10 @@ var getOrganizationCmd = &cobra.Command{
 
 		orgs := resource.NewOrganizations(resp)
 
+		if len(args) == 1 {
+			resource.Organization().DisableListView()
+		}
+
 		if mineOnly {
 			me, err := getMyAccountID()
 			if err != nil {

--- a/cmd/get_plugin.go
+++ b/cmd/get_plugin.go
@@ -33,6 +33,11 @@ var getPluginCmd = &cobra.Command{
 		}
 
 		plugs := resource.NewPlugins(resp)
+
+		if len(args) == 1 {
+			resource.Plugin().DisableListView()
+		}
+
 		outputResponse(plugs)
 		return nil
 	},

--- a/cmd/get_plugin_catalog.go
+++ b/cmd/get_plugin_catalog.go
@@ -65,6 +65,10 @@ var getPluginCatalogCmd = &cobra.Command{
 			return errors.New("invalid flag combination - see usage")
 		}
 
+		if len(args) == 1 {
+			resource.PluginCatalog().DisableListView()
+		}
+
 		outputResponse(plugins)
 		return nil
 	},

--- a/cmd/get_provider.go
+++ b/cmd/get_provider.go
@@ -34,6 +34,10 @@ var getProviderCmd = &cobra.Command{
 
 		providers := resource.NewProviders(resp)
 
+		if len(args) == 1 {
+			resource.Provider().DisableListView()
+		}
+
 		outputResponse(providers)
 		return nil
 	},

--- a/cmd/get_registry.go
+++ b/cmd/get_registry.go
@@ -33,6 +33,11 @@ var getRegistryCmd = &cobra.Command{
 		}
 
 		regs := resource.NewRegistries(resp)
+
+		if len(args) == 1 {
+			resource.Registry().DisableListView()
+		}
+
 		outputResponse(regs)
 		return nil
 	},

--- a/cmd/get_template.go
+++ b/cmd/get_template.go
@@ -35,7 +35,7 @@ var getTemplateCmd = &cobra.Command{
 		templates := resource.NewTemplates(resp)
 
 		if len(args) == 1 {
-			templates.DisableItemListView()
+			resource.Template().DisableListView()
 		}
 
 		if mineOnly {

--- a/cmd/get_template.go
+++ b/cmd/get_template.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/containership/csctl/cloud/provision/types"
 	"github.com/containership/csctl/resource"
-	"github.com/spf13/cobra"
 )
 
 // getTemplateCmd represents the getTemplate command

--- a/cmd/get_template.go
+++ b/cmd/get_template.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/containership/csctl/cloud/provision/types"
 	"github.com/containership/csctl/resource"
+	"github.com/spf13/cobra"
 )
 
 // getTemplateCmd represents the getTemplate command
@@ -33,6 +32,10 @@ var getTemplateCmd = &cobra.Command{
 		}
 
 		templates := resource.NewTemplates(resp)
+
+		if len(args) == 1 {
+			templates.DisableItemListView()
+		}
 
 		if mineOnly {
 			me, err := getMyAccountID()

--- a/cmd/get_user.go
+++ b/cmd/get_user.go
@@ -26,6 +26,10 @@ var getUserCmd = &cobra.Command{
 
 		users := resource.NewUsers(resp)
 
+		if len(args) == 1 {
+			resource.User().DisableListView()
+		}
+
 		outputResponse(users)
 		return nil
 	},

--- a/resource/access_tokens.go
+++ b/resource/access_tokens.go
@@ -19,9 +19,10 @@ type AccessTokens struct {
 func NewAccessTokens(items []types.AccessToken) *AccessTokens {
 	return &AccessTokens{
 		resource: resource{
-			name:    "access-token",
-			plural:  "access-tokens",
-			aliases: []string{"token", "tokens"},
+			name:     "access-token",
+			plural:   "access-tokens",
+			aliases:  []string{"token", "tokens"},
+			listView: true,
 		},
 		items: items,
 	}
@@ -60,12 +61,12 @@ func (t *AccessTokens) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (t *AccessTokens) JSON(w io.Writer) error {
-	return displayJSON(w, t.items)
+	return displayJSON(w, t.items, t.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (t *AccessTokens) YAML(w io.Writer) error {
-	return displayYAML(w, t.items)
+	return displayYAML(w, t.items, t.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/accounts.go
+++ b/resource/accounts.go
@@ -18,8 +18,9 @@ type Accounts struct {
 func NewAccounts(items []types.Account) *Accounts {
 	return &Accounts{
 		resource: resource{
-			name:    "account",
-			aliases: []string{"acct"},
+			name:     "account",
+			aliases:  []string{"acct"},
+			listView: true,
 		},
 		items: items,
 	}
@@ -58,12 +59,12 @@ func (a *Accounts) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (a *Accounts) JSON(w io.Writer) error {
-	return displayJSON(w, a.items)
+	return displayJSON(w, a.items, a.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (a *Accounts) YAML(w io.Writer) error {
-	return displayYAML(w, a.items)
+	return displayYAML(w, a.items, a.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/accounts_test.go
+++ b/resource/accounts_test.go
@@ -24,6 +24,13 @@ var (
 			CreatedAt: &acctTime,
 		},
 	}
+	acctSingle = []types.Account{
+		{
+			Name:      strptr("test3"),
+			ID:        types.UUID("1234"),
+			CreatedAt: &acctTime,
+		},
+	}
 )
 
 func TestNewAccounts(t *testing.T) {
@@ -36,6 +43,13 @@ func TestNewAccounts(t *testing.T) {
 
 	a = Account()
 	assert.NotNil(t, a)
+}
+
+func TestAccountsDisableListView(t *testing.T) {
+	a := NewAccounts(nil)
+	assert.NotNil(t, a)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestAccountsTable(t *testing.T) {
@@ -52,4 +66,24 @@ func TestAccountsTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(accts), info.numRows)
+}
+
+func TestAccountsJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewAccounts(acctSingle)
+	err := a.JSON(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestAccountsYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewAccounts(acctSingle)
+	err := a.YAML(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.YAML(buf)
+	assert.Nil(t, err)
 }

--- a/resource/autoscaling_policies.go
+++ b/resource/autoscaling_policies.go
@@ -18,9 +18,10 @@ type AutoscalingPolicies struct {
 func NewAutoscalingPolicies(items []types.AutoscalingPolicy) *AutoscalingPolicies {
 	return &AutoscalingPolicies{
 		resource: resource{
-			name:    "autoscaling-policy",
-			plural:  "autoscaling-policies",
-			aliases: []string{"asp", "asps"},
+			name:     "autoscaling-policy",
+			plural:   "autoscaling-policies",
+			aliases:  []string{"asp", "asps"},
+			listView: true,
 		},
 		items: items,
 	}
@@ -99,12 +100,12 @@ func getPolicyConfiguration(config *types.ScalingPolicyConfiguration, scaleDown 
 
 // JSON outputs the JSON representation to the given writer
 func (p *AutoscalingPolicies) JSON(w io.Writer) error {
-	return displayJSON(w, p.items)
+	return displayJSON(w, p.items, p.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *AutoscalingPolicies) YAML(w io.Writer) error {
-	return displayYAML(w, p.items)
+	return displayYAML(w, p.items, p.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/autoscaling_policies_test.go
+++ b/resource/autoscaling_policies_test.go
@@ -65,6 +65,30 @@ var (
 			SamplePeriod:   int32ptr(800),
 		},
 	}
+	aspsSingle = []types.AutoscalingPolicy{
+		{
+			Name:           strptr("test4"),
+			ID:             types.UUID("1234"),
+			MetricsBackend: "prometheus",
+			Metric:         strptr("cpu"),
+			ScalingPolicy: &types.ScalingPolicy{
+				ScaleUp: &types.ScalingPolicyConfiguration{
+					AdjustmentType:     strptr("percent"),
+					AdjustmentValue:    float32ptr(10),
+					ComparisonOperator: strptr(">="),
+					Threshold:          float32ptr(0.5),
+				},
+				ScaleDown: &types.ScalingPolicyConfiguration{
+					AdjustmentType:     strptr("percent"),
+					AdjustmentValue:    float32ptr(30),
+					ComparisonOperator: strptr("<"),
+					Threshold:          float32ptr(0.3),
+				},
+			},
+			PollInterval: int32ptr(15),
+			SamplePeriod: int32ptr(600),
+		},
+	}
 )
 
 func TestNewAutoscalingPolicies(t *testing.T) {
@@ -77,6 +101,13 @@ func TestNewAutoscalingPolicies(t *testing.T) {
 
 	a = AutoscalingPolicy()
 	assert.NotNil(t, a)
+}
+
+func TestAutoscalingPoliciesDisableListView(t *testing.T) {
+	a := NewAutoscalingPolicies(aspsSingle)
+	assert.NotNil(t, a)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestAutoscalingPoliciesTable(t *testing.T) {
@@ -93,4 +124,24 @@ func TestAutoscalingPoliciesTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(asps), info.numRows)
+}
+
+func TestAutoscalingPoliciesJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewAutoscalingPolicies(aspsSingle)
+	err := a.JSON(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestAutoscalingPoliciesYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewAutoscalingPolicies(aspsSingle)
+	err := a.YAML(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.YAML(buf)
+	assert.Nil(t, err)
 }

--- a/resource/cke_clusters.go
+++ b/resource/cke_clusters.go
@@ -12,25 +12,19 @@ import (
 type CKEClusters struct {
 	resource
 	filterable
-	items    []types.CKECluster
-	listview bool
+	items []types.CKECluster
 }
 
 // NewCKEClusters constructs a new CKEClusters wrapping the given cloud type
 func NewCKEClusters(items []types.CKECluster) *CKEClusters {
 	return &CKEClusters{
 		resource: resource{
-			name:   "cluster",
-			plural: "clusters",
+			name:     "cluster",
+			plural:   "clusters",
+			listView: true,
 		},
-		items:    items,
-		listview: true,
+		items: items,
 	}
-}
-
-// DisableItemListView sets to output a single value of item
-func (c *CKEClusters) DisableItemListView() {
-	c.listview = false
 }
 
 // CKECluster constructs a new CKEClusters with no underlying items, useful for
@@ -70,18 +64,12 @@ func (c *CKEClusters) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (c *CKEClusters) JSON(w io.Writer) error {
-	if !c.listview && len(c.items) == 1 {
-		return displayJSON(w, c.items[0])
-	}
-	return displayJSON(w, c.items)
+	return displayJSON(w, c.items, c.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (c *CKEClusters) YAML(w io.Writer) error {
-	if !c.listview && len(c.items) == 1 {
-		return displayYAML(w, c.items[0])
-	}
-	return displayYAML(w, c.items)
+	return displayYAML(w, c.items, c.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/cke_clusters.go
+++ b/resource/cke_clusters.go
@@ -12,7 +12,8 @@ import (
 type CKEClusters struct {
 	resource
 	filterable
-	items []types.CKECluster
+	items    []types.CKECluster
+	listview bool
 }
 
 // NewCKEClusters constructs a new CKEClusters wrapping the given cloud type
@@ -22,8 +23,14 @@ func NewCKEClusters(items []types.CKECluster) *CKEClusters {
 			name:   "cluster",
 			plural: "clusters",
 		},
-		items: items,
+		items:    items,
+		listview: true,
 	}
+}
+
+// DisableItemListView sets to output a single value of item
+func (c *CKEClusters) DisableItemListView() {
+	c.listview = false
 }
 
 // CKECluster constructs a new CKEClusters with no underlying items, useful for
@@ -63,11 +70,17 @@ func (c *CKEClusters) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (c *CKEClusters) JSON(w io.Writer) error {
+	if !c.listview && len(c.items) == 1 {
+		return displayJSON(w, c.items[0])
+	}
 	return displayJSON(w, c.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (c *CKEClusters) YAML(w io.Writer) error {
+	if !c.listview && len(c.items) == 1 {
+		return displayYAML(w, c.items[0])
+	}
 	return displayYAML(w, c.items)
 }
 

--- a/resource/cke_clusters_test.go
+++ b/resource/cke_clusters_test.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/containership/csctl/cloud/provision/types"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -32,6 +31,17 @@ var (
 			CreatedAt: &ckeClusterTime,
 		},
 	}
+	ckeClusterSingle = []types.CKECluster{
+		{
+			ID:           types.UUID("1111"),
+			ProviderName: strptr("facebook"),
+			Status: &types.CKEClusterStatus{
+				Type: strptr("RUNNING"),
+			},
+			OwnerID:   types.UUID("1111"),
+			CreatedAt: &ckeClusterTime,
+		},
+	}
 )
 
 func TestNewCKEClusters(t *testing.T) {
@@ -44,6 +54,13 @@ func TestNewCKEClusters(t *testing.T) {
 
 	a = CKECluster()
 	assert.NotNil(t, a)
+}
+
+func TestCKEClustersDisableItemListView(t *testing.T) {
+	a := NewCKEClusters(nil)
+	assert.NotNil(t, a)
+	a.DisableItemListView()
+	assert.Equal(t, a.listview, false)
 }
 
 func TestCKEClustersTable(t *testing.T) {
@@ -60,4 +77,24 @@ func TestCKEClustersTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(ckeClusters), info.numRows)
+}
+
+func TestCKEClustersJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	cluster := NewCKEClusters(ckeClusterSingle)
+	err := cluster.JSON(buf)
+	assert.Nil(t, err)
+	cluster.DisableItemListView()
+	err = cluster.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestCKEClustersYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	cluster := NewCKEClusters(ckeClusterSingle)
+	err := cluster.YAML(buf)
+	assert.Nil(t, err)
+	cluster.DisableItemListView()
+	err = cluster.YAML(buf)
+	assert.Nil(t, err)
 }

--- a/resource/cke_clusters_test.go
+++ b/resource/cke_clusters_test.go
@@ -56,11 +56,11 @@ func TestNewCKEClusters(t *testing.T) {
 	assert.NotNil(t, a)
 }
 
-func TestCKEClustersDisableItemListView(t *testing.T) {
+func TestCKEClustersDisableListView(t *testing.T) {
 	a := NewCKEClusters(nil)
 	assert.NotNil(t, a)
-	a.DisableItemListView()
-	assert.Equal(t, a.listview, false)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestCKEClustersTable(t *testing.T) {
@@ -84,7 +84,7 @@ func TestCKEClustersJSON(t *testing.T) {
 	cluster := NewCKEClusters(ckeClusterSingle)
 	err := cluster.JSON(buf)
 	assert.Nil(t, err)
-	cluster.DisableItemListView()
+	cluster.resource.DisableListView()
 	err = cluster.JSON(buf)
 	assert.Nil(t, err)
 }
@@ -94,7 +94,7 @@ func TestCKEClustersYAML(t *testing.T) {
 	cluster := NewCKEClusters(ckeClusterSingle)
 	err := cluster.YAML(buf)
 	assert.Nil(t, err)
-	cluster.DisableItemListView()
+	cluster.resource.DisableListView()
 	err = cluster.YAML(buf)
 	assert.Nil(t, err)
 }

--- a/resource/cke_clusters_test.go
+++ b/resource/cke_clusters_test.go
@@ -34,7 +34,7 @@ var (
 	ckeClusterSingle = []types.CKECluster{
 		{
 			ID:           types.UUID("1111"),
-			ProviderName: strptr("facebook"),
+			ProviderName: strptr("google"),
 			Status: &types.CKEClusterStatus{
 				Type: strptr("RUNNING"),
 			},

--- a/resource/display.go
+++ b/resource/display.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/containership/csctl/cloud/provision/types"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/util/jsonpath"
@@ -21,8 +22,18 @@ type Displayable interface {
 	JSONPath(w io.Writer, template string) error
 }
 
-func displayJSON(w io.Writer, data interface{}) error {
-	j, err := json.MarshalIndent(data, "", "  ")
+func assertTypes(data interface{}, listView bool) interface{} {
+	switch val := data.(type) {
+	case []types.Template:
+		if len(val) == 1 && !listView {
+			return val[1:]
+		}
+	}
+	return data
+}
+
+func displayJSON(w io.Writer, data interface{}, listView bool) error {
+	j, err := json.MarshalIndent(assertTypes(data, listView), "", "  ")
 	if err != nil {
 		return errors.Wrap(err, "marshaling to JSON")
 	}
@@ -32,8 +43,8 @@ func displayJSON(w io.Writer, data interface{}) error {
 	return nil
 }
 
-func displayYAML(w io.Writer, data interface{}) error {
-	j, err := json.Marshal(data)
+func displayYAML(w io.Writer, data interface{}, listView bool) error {
+	j, err := json.Marshal(assertTypes(data, listView))
 	if err != nil {
 		return errors.Wrap(err, "marshaling to JSON")
 	}

--- a/resource/node_pools.go
+++ b/resource/node_pools.go
@@ -17,9 +17,10 @@ type NodePools struct {
 func NewNodePools(items []types.NodePool) *NodePools {
 	return &NodePools{
 		resource: resource{
-			name:    "node-pool",
-			plural:  "node-pools",
-			aliases: []string{"nodepool", "nodepools", "np", "nps"},
+			name:     "node-pool",
+			plural:   "node-pools",
+			aliases:  []string{"nodepool", "nodepools", "np", "nps"},
+			listView: true,
 		},
 		items: items,
 	}
@@ -81,12 +82,12 @@ func (p *NodePools) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (p *NodePools) JSON(w io.Writer) error {
-	return displayJSON(w, p.items)
+	return displayJSON(w, p.items, p.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *NodePools) YAML(w io.Writer) error {
-	return displayYAML(w, p.items)
+	return displayYAML(w, p.items, p.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/node_pools_test.go
+++ b/resource/node_pools_test.go
@@ -31,6 +31,16 @@ var (
 			DockerVersion:     &dockerVersion,
 		},
 	}
+	npsSingle = []types.NodePool{
+		{
+			Name:              strptr("test3"),
+			ID:                types.UUID("1234"),
+			KubernetesMode:    strptr("master"),
+			KubernetesVersion: strptr("1.12.1"),
+			EtcdVersion:       &etcdVersion,
+			DockerVersion:     &dockerVersion,
+		},
+	}
 )
 
 func TestNewNodePools(t *testing.T) {
@@ -43,6 +53,13 @@ func TestNewNodePools(t *testing.T) {
 
 	a = NodePool()
 	assert.NotNil(t, a)
+}
+
+func TestNodePoolsDisableListView(t *testing.T) {
+	a := NewNodePools(npsSingle)
+	assert.NotNil(t, a)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestNodePoolsTable(t *testing.T) {
@@ -59,4 +76,24 @@ func TestNodePoolsTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(nps), info.numRows)
+}
+
+func TestNodePoolsJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewNodePools(npsSingle)
+	err := a.JSON(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestNodePoolsYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewNodePools(npsSingle)
+	err := a.YAML(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.YAML(buf)
+	assert.Nil(t, err)
 }

--- a/resource/nodes.go
+++ b/resource/nodes.go
@@ -18,9 +18,10 @@ type Nodes struct {
 func NewNodes(items []types.Node) *Nodes {
 	return &Nodes{
 		resource: resource{
-			name:    "node",
-			plural:  "nodes",
-			aliases: []string{"no", "nos"},
+			name:     "node",
+			plural:   "nodes",
+			aliases:  []string{"no", "nos"},
+			listView: true,
 		},
 		items: items,
 	}
@@ -69,12 +70,12 @@ func (p *Nodes) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (p *Nodes) JSON(w io.Writer) error {
-	return displayJSON(w, p.items)
+	return displayJSON(w, p.items, p.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *Nodes) YAML(w io.Writer) error {
-	return displayYAML(w, p.items)
+	return displayYAML(w, p.items, p.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/nodes_test.go
+++ b/resource/nodes_test.go
@@ -30,6 +30,16 @@ var (
 			UpdatedAt: &nodeTime,
 		},
 	}
+	nodesSingle = []types.Node{
+		{
+			ID: types.UUID("1234"),
+			Status: &types.NodeStatus{
+				Type: strptr("RUNNING"),
+			},
+			CreatedAt: &nodeTime,
+			UpdatedAt: &nodeTime,
+		},
+	}
 )
 
 func TestNewNodes(t *testing.T) {
@@ -42,6 +52,13 @@ func TestNewNodes(t *testing.T) {
 
 	a = Node()
 	assert.NotNil(t, a)
+}
+
+func TestNodesDisableListView(t *testing.T) {
+	a := NewNodes(nodesSingle)
+	assert.NotNil(t, a)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestNodesTable(t *testing.T) {
@@ -58,4 +75,24 @@ func TestNodesTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(nodes), info.numRows)
+}
+
+func TestNodesJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewNodes(nodesSingle)
+	err := a.JSON(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestNodesYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewNodes(nodesSingle)
+	err := a.YAML(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.YAML(buf)
+	assert.Nil(t, err)
 }

--- a/resource/organizations.go
+++ b/resource/organizations.go
@@ -19,9 +19,10 @@ type Organizations struct {
 func NewOrganizations(items []types.Organization) *Organizations {
 	return &Organizations{
 		resource: resource{
-			name:    "organization",
-			plural:  "organizations",
-			aliases: []string{"org", "orgs"},
+			name:     "organization",
+			plural:   "organizations",
+			aliases:  []string{"org", "orgs"},
+			listView: true,
 		},
 		items: items,
 	}
@@ -62,12 +63,12 @@ func (o *Organizations) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (o *Organizations) JSON(w io.Writer) error {
-	return displayJSON(w, o.items)
+	return displayJSON(w, o.items, o.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (o *Organizations) YAML(w io.Writer) error {
-	return displayYAML(w, o.items)
+	return displayYAML(w, o.items, o.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/organizations_test.go
+++ b/resource/organizations_test.go
@@ -26,6 +26,14 @@ var (
 			CreatedAt: &orgTime,
 		},
 	}
+	orgsSingle = []types.Organization{
+		{
+			Name:      strptr("test3"),
+			ID:        types.UUID("1234"),
+			OwnerID:   types.UUID("1234"),
+			CreatedAt: &orgTime,
+		},
+	}
 )
 
 func TestNewOrganizations(t *testing.T) {
@@ -38,6 +46,13 @@ func TestNewOrganizations(t *testing.T) {
 
 	a = Organization()
 	assert.NotNil(t, a)
+}
+
+func TestOrganizationsDisableListView(t *testing.T) {
+	a := NewOrganizations(orgsSingle)
+	assert.NotNil(t, a)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestOrganizationsTable(t *testing.T) {
@@ -54,4 +69,24 @@ func TestOrganizationsTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(orgs), info.numRows)
+}
+
+func TestOrganizationsJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewOrganizations(orgsSingle)
+	err := a.JSON(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestOrganizationsYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewOrganizations(orgsSingle)
+	err := a.YAML(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.YAML(buf)
+	assert.Nil(t, err)
 }

--- a/resource/plugin_catalog.go
+++ b/resource/plugin_catalog.go
@@ -17,8 +17,9 @@ type PluginsCatalog struct {
 func NewPluginCatalog(item *types.PluginCatalog) *PluginsCatalog {
 	return &PluginsCatalog{
 		resource: resource{
-			name:    "plugin-catalog",
-			aliases: []string{"plgnc", "plugc", "pc"},
+			name:     "plugin-catalog",
+			aliases:  []string{"plgnc", "plugc", "pc"},
+			listView: true,
 		},
 		items: item,
 	}
@@ -121,12 +122,12 @@ func (pc *PluginsCatalog) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (pc *PluginsCatalog) JSON(w io.Writer) error {
-	return displayJSON(w, pc.items)
+	return displayJSON(w, pc.items, pc.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (pc *PluginsCatalog) YAML(w io.Writer) error {
-	return displayYAML(w, pc.items)
+	return displayYAML(w, pc.items, pc.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/plugin_catalog_test.go
+++ b/resource/plugin_catalog_test.go
@@ -131,6 +131,31 @@ var (
 			},
 		},
 	}
+	plugsCatalogSingle = &types.PluginCatalog{
+		Autoscaler: []*types.PluginDefinition{
+			{
+				Implementation: strptr("cerebral"),
+				Versions: []*types.PluginVersion{
+					{
+						Version: strptr("1.0.0"),
+						Compatibility: &types.PluginCompatibility{
+							Kubernetes: &types.PluginKubernetesCompatibility{
+								Min: strptr("1.10.x"),
+								Max: strptr("1.12.x"),
+							},
+							Plugins: map[string]types.PluginPluginsCompatibility{
+								"Metrics": {
+									Implementation: strptr("prometheus"),
+									Min:            strptr("1.0.0"),
+									Max:            strptr("1.1.0"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 )
 
 func TestNewPluginCatalog(t *testing.T) {
@@ -143,6 +168,13 @@ func TestNewPluginCatalog(t *testing.T) {
 
 	pc = PluginCatalog()
 	assert.NotNil(t, pc)
+}
+
+func TestPluginCatalogsDisableListView(t *testing.T) {
+	a := NewPluginCatalog(plugsCatalogSingle)
+	assert.NotNil(t, a)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestNewPluginCatalogFromDefinition(t *testing.T) {
@@ -214,4 +246,24 @@ func TestPluginCatalogTable(t *testing.T) {
 	l += len(plugsCatalog.Metrics)
 
 	assert.Equal(t, l, info.numRows)
+}
+
+func TestPluginCatalogJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewPluginCatalog(plugsCatalogSingle)
+	err := a.JSON(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestPluginCatalogYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewPluginCatalog(plugsCatalogSingle)
+	err := a.YAML(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.YAML(buf)
+	assert.Nil(t, err)
 }

--- a/resource/plugins.go
+++ b/resource/plugins.go
@@ -19,9 +19,10 @@ type Plugins struct {
 func NewPlugins(items []types.Plugin) *Plugins {
 	return &Plugins{
 		resource: resource{
-			name:    "plugin",
-			plural:  "plugins",
-			aliases: []string{"plug", "plugs", "plgn", "plgns"},
+			name:     "plugin",
+			plural:   "plugins",
+			aliases:  []string{"plug", "plugs", "plgn", "plgns"},
+			listView: true,
 		},
 		items: items,
 	}
@@ -64,12 +65,12 @@ func (p *Plugins) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (p *Plugins) JSON(w io.Writer) error {
-	return displayJSON(w, p.items)
+	return displayJSON(w, p.items, p.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *Plugins) YAML(w io.Writer) error {
-	return displayYAML(w, p.items)
+	return displayYAML(w, p.items, p.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/plugins_test.go
+++ b/resource/plugins_test.go
@@ -28,6 +28,15 @@ var (
 			CreatedAt:      &plugTime,
 		},
 	}
+	plugsSingle = []types.Plugin{
+		{
+			ID:             types.UUID("1234"),
+			Type:           strptr("logs"),
+			Implementation: strptr("kubernetes"),
+			Version:        strptr("v1.0.0"),
+			CreatedAt:      &plugTime,
+		},
+	}
 )
 
 func TestNewPlugins(t *testing.T) {
@@ -40,6 +49,13 @@ func TestNewPlugins(t *testing.T) {
 
 	a = Plugin()
 	assert.NotNil(t, a)
+}
+
+func TestPluginsDisableListView(t *testing.T) {
+	a := NewPlugins(plugsSingle)
+	assert.NotNil(t, a)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestPluginsTable(t *testing.T) {
@@ -56,4 +72,24 @@ func TestPluginsTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(plugs), info.numRows)
+}
+
+func TestPluginsJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewPlugins(plugsSingle)
+	err := a.JSON(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestPluginsYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewPlugins(plugsSingle)
+	err := a.YAML(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.YAML(buf)
+	assert.Nil(t, err)
 }

--- a/resource/providers.go
+++ b/resource/providers.go
@@ -18,8 +18,9 @@ type Providers struct {
 func NewProviders(items []types.Provider) *Providers {
 	return &Providers{
 		resource: resource{
-			name:   "provider",
-			plural: "providers",
+			name:     "provider",
+			plural:   "providers",
+			listView: true,
 		},
 		items: items,
 	}
@@ -60,12 +61,12 @@ func (c *Providers) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (c *Providers) JSON(w io.Writer) error {
-	return displayJSON(w, c.items)
+	return displayJSON(w, c.items, c.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (c *Providers) YAML(w io.Writer) error {
-	return displayYAML(w, c.items)
+	return displayYAML(w, c.items, c.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/providers_test.go
+++ b/resource/providers_test.go
@@ -26,6 +26,14 @@ var (
 			CreatedAt:   &providerTime,
 		},
 	}
+	providersSingle = []types.Provider{
+		{
+			ID:          types.UUID("1234"),
+			Provider:    strptr("google"),
+			Description: strptr("google description"),
+			CreatedAt:   &providerTime,
+		},
+	}
 )
 
 func TestNewProviders(t *testing.T) {
@@ -38,6 +46,13 @@ func TestNewProviders(t *testing.T) {
 
 	a = Provider()
 	assert.NotNil(t, a)
+}
+
+func TestProvidersDisableListView(t *testing.T) {
+	a := NewProviders(providersSingle)
+	assert.NotNil(t, a)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestProvidersTable(t *testing.T) {
@@ -54,4 +69,24 @@ func TestProvidersTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(providers), info.numRows)
+}
+
+func TestProvidersJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewProviders(providersSingle)
+	err := a.JSON(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestProvidersYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewProviders(providersSingle)
+	err := a.YAML(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.YAML(buf)
+	assert.Nil(t, err)
 }

--- a/resource/registries.go
+++ b/resource/registries.go
@@ -19,9 +19,10 @@ type Registries struct {
 func NewRegistries(items []types.Registry) *Registries {
 	return &Registries{
 		resource: resource{
-			name:    "registry",
-			plural:  "registries",
-			aliases: []string{"reg", "regs"},
+			name:     "registry",
+			plural:   "registries",
+			aliases:  []string{"reg", "regs"},
+			listView: true,
 		},
 		items: items,
 	}
@@ -64,12 +65,12 @@ func (p *Registries) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (p *Registries) JSON(w io.Writer) error {
-	return displayJSON(w, p.items)
+	return displayJSON(w, p.items, p.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *Registries) YAML(w io.Writer) error {
-	return displayYAML(w, p.items)
+	return displayYAML(w, p.items, p.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/registries_test.go
+++ b/resource/registries_test.go
@@ -28,6 +28,15 @@ var (
 			Serveraddress: strptr("2.0.0"),
 		},
 	}
+	regsSingle = []types.Registry{
+		{
+			ID:            types.UUID("1234"),
+			CreatedAt:     &regTime,
+			Description:   strptr("logs"),
+			Provider:      strptr("kubernetes"),
+			Serveraddress: strptr("v1.0.0"),
+		},
+	}
 )
 
 func TestNewRegistries(t *testing.T) {
@@ -42,6 +51,12 @@ func TestNewRegistries(t *testing.T) {
 	assert.NotNil(t, a)
 }
 
+func TestRegistriesDisableListView(t *testing.T) {
+	a := NewRegistries(regsSingle)
+	assert.NotNil(t, a)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
+}
 func TestRegistriesTable(t *testing.T) {
 	buf := new(bytes.Buffer)
 
@@ -56,4 +71,24 @@ func TestRegistriesTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(regs), info.numRows)
+}
+
+func TestRegistriesJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewRegistries(regsSingle)
+	err := a.JSON(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestRegistriesYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewRegistries(regsSingle)
+	err := a.YAML(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.YAML(buf)
+	assert.Nil(t, err)
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -11,14 +11,16 @@ type resourceInterface interface {
 	Plural() string
 	Aliases() []string
 	HasAlias(name string) bool
+	DisableListView()
 }
 
 type resource struct {
 	resourceInterface
 
-	name    string
-	plural  string
-	aliases []string
+	name     string
+	plural   string
+	aliases  []string
+	listView bool
 }
 
 func (r *resource) Name() string {
@@ -35,4 +37,8 @@ func (r *resource) Aliases() []string {
 	}
 
 	return r.aliases
+}
+
+func (r *resource) DisableListView() {
+	r.listView = false
 }

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -42,3 +42,13 @@ func TestAliases(t *testing.T) {
 	r.plural = "plugins"
 	assert.Equal(t, r.Aliases(), []string{r.plural}, "plural only")
 }
+
+func TestDisableListView(t *testing.T) {
+	r := resource{
+		name:     "plugin",
+		plural:   "plugins",
+		listView: true,
+	}
+	r.DisableListView()
+	assert.Equal(t, r.listView, false)
+}

--- a/resource/templates.go
+++ b/resource/templates.go
@@ -3,18 +3,18 @@ package resource
 import (
 	"io"
 
-	"github.com/pkg/errors"
-
 	"github.com/containership/csctl/cloud/provision/types"
 	"github.com/containership/csctl/pkg/convert"
 	"github.com/containership/csctl/resource/table"
+	"github.com/pkg/errors"
 )
 
 // Templates is a list of the associated cloud resource with additional functionality
 type Templates struct {
 	resource
 	filterable
-	items []types.Template
+	items    []types.Template
+	listview bool
 }
 
 // filterFunc returns true if the item should be filtered in
@@ -31,7 +31,8 @@ func NewTemplates(items []types.Template) *Templates {
 			plural:  "templates",
 			aliases: []string{"tmpl", "tmpls"},
 		},
-		items: items,
+		items:    items,
+		listview: true,
 	}
 }
 
@@ -50,6 +51,11 @@ func (c *Templates) columns() []string {
 		"Owner ID",
 		"Created At",
 	}
+}
+
+// DisableItemListView sets to output a single value of item
+func (c *Templates) DisableItemListView() {
+	c.listview = false
 }
 
 // Table outputs the table representation to the given writer
@@ -84,11 +90,17 @@ func (c *Templates) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (c *Templates) JSON(w io.Writer) error {
+	if !c.listview && len(c.items) == 1 {
+		return displayJSON(w, c.items[0])
+	}
 	return displayJSON(w, c.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (c *Templates) YAML(w io.Writer) error {
+	if !c.listview && len(c.items) == 1 {
+		return displayYAML(w, c.items[0])
+	}
 	return displayYAML(w, c.items)
 }
 

--- a/resource/templates.go
+++ b/resource/templates.go
@@ -14,8 +14,7 @@ import (
 type Templates struct {
 	resource
 	filterable
-	items    []types.Template
-	listview bool
+	items []types.Template
 }
 
 // filterFunc returns true if the item should be filtered in
@@ -28,12 +27,12 @@ type filterFunc func(types.Template) bool
 func NewTemplates(items []types.Template) *Templates {
 	return &Templates{
 		resource: resource{
-			name:    "template",
-			plural:  "templates",
-			aliases: []string{"tmpl", "tmpls"},
+			name:     "template",
+			plural:   "templates",
+			aliases:  []string{"tmpl", "tmpls"},
+			listView: true,
 		},
-		items:    items,
-		listview: true,
+		items: items,
 	}
 }
 
@@ -52,11 +51,6 @@ func (c *Templates) columns() []string {
 		"Owner ID",
 		"Created At",
 	}
-}
-
-// DisableItemListView sets to output a single value of item
-func (c *Templates) DisableItemListView() {
-	c.listview = false
 }
 
 // Table outputs the table representation to the given writer
@@ -91,18 +85,12 @@ func (c *Templates) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (c *Templates) JSON(w io.Writer) error {
-	if !c.listview && len(c.items) == 1 {
-		return displayJSON(w, c.items[0])
-	}
-	return displayJSON(w, c.items)
+	return displayJSON(w, c.items, c.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (c *Templates) YAML(w io.Writer) error {
-	if !c.listview && len(c.items) == 1 {
-		return displayYAML(w, c.items[0])
-	}
-	return displayYAML(w, c.items)
+	return displayYAML(w, c.items, c.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/templates.go
+++ b/resource/templates.go
@@ -3,10 +3,11 @@ package resource
 import (
 	"io"
 
+	"github.com/pkg/errors"
+
 	"github.com/containership/csctl/cloud/provision/types"
 	"github.com/containership/csctl/pkg/convert"
 	"github.com/containership/csctl/resource/table"
-	"github.com/pkg/errors"
 )
 
 // Templates is a list of the associated cloud resource with additional functionality

--- a/resource/templates_test.go
+++ b/resource/templates_test.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/containership/csctl/cloud/provision/types"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -55,6 +54,9 @@ var (
 			Configuration: &tmplConfig,
 		},
 	}
+	tmplSingle = []types.Template{
+		tmplGood,
+	}
 )
 
 func TestNewTemplates(t *testing.T) {
@@ -67,6 +69,13 @@ func TestNewTemplates(t *testing.T) {
 
 	a = Template()
 	assert.NotNil(t, a)
+}
+
+func TestDisableItemListView(t *testing.T) {
+	a := NewTemplates(nil)
+	assert.NotNil(t, a)
+	a.DisableItemListView()
+	assert.Equal(t, a.listview, false)
 }
 
 func TestTemplatesTable(t *testing.T) {
@@ -161,4 +170,24 @@ func TestGetMasterKubernetesVersion(t *testing.T) {
 	v, err = getMasterKubernetesVersion(&tmplGood)
 	assert.Nil(t, err)
 	assert.Equal(t, v, tmplK8sVersion)
+}
+
+func TestTemplatesJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	templs := NewTemplates(tmplSingle)
+	err := templs.JSON(buf)
+	assert.Nil(t, err)
+	templs.DisableItemListView()
+	err = templs.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestTemplatesYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	templs := NewTemplates(tmplSingle)
+	err := templs.YAML(buf)
+	assert.Nil(t, err)
+	templs.DisableItemListView()
+	err = templs.YAML(buf)
+	assert.Nil(t, err)
 }

--- a/resource/templates_test.go
+++ b/resource/templates_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/containership/csctl/cloud/provision/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containership/csctl/cloud/provision/types"
 )
 
 var (

--- a/resource/templates_test.go
+++ b/resource/templates_test.go
@@ -72,11 +72,11 @@ func TestNewTemplates(t *testing.T) {
 	assert.NotNil(t, a)
 }
 
-func TestDisableItemListView(t *testing.T) {
+func TestTemplatesDisableListView(t *testing.T) {
 	a := NewTemplates(nil)
 	assert.NotNil(t, a)
-	a.DisableItemListView()
-	assert.Equal(t, a.listview, false)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestTemplatesTable(t *testing.T) {
@@ -178,7 +178,7 @@ func TestTemplatesJSON(t *testing.T) {
 	templs := NewTemplates(tmplSingle)
 	err := templs.JSON(buf)
 	assert.Nil(t, err)
-	templs.DisableItemListView()
+	templs.DisableListView()
 	err = templs.JSON(buf)
 	assert.Nil(t, err)
 }
@@ -188,7 +188,7 @@ func TestTemplatesYAML(t *testing.T) {
 	templs := NewTemplates(tmplSingle)
 	err := templs.YAML(buf)
 	assert.Nil(t, err)
-	templs.DisableItemListView()
+	templs.DisableListView()
 	err = templs.YAML(buf)
 	assert.Nil(t, err)
 }

--- a/resource/users.go
+++ b/resource/users.go
@@ -19,9 +19,10 @@ type Users struct {
 func NewUsers(items []types.User) *Users {
 	return &Users{
 		resource: resource{
-			name:    "user",
-			plural:  "users",
-			aliases: []string{"usr", "usrs"},
+			name:     "user",
+			plural:   "users",
+			aliases:  []string{"usr", "usrs"},
+			listView: true,
 		},
 		items: items,
 	}
@@ -62,12 +63,12 @@ func (c *Users) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (c *Users) JSON(w io.Writer) error {
-	return displayJSON(w, c.items)
+	return displayJSON(w, c.items, c.resource.listView)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (c *Users) YAML(w io.Writer) error {
-	return displayYAML(w, c.items)
+	return displayYAML(w, c.items, c.resource.listView)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/users_test.go
+++ b/resource/users_test.go
@@ -26,6 +26,14 @@ var (
 			AddedAt: &userTime,
 		},
 	}
+	usersSingle = []types.User{
+		{
+			ID:      types.UUID("1234"),
+			Name:    strptr("Yugo H"),
+			Email:   strptr("y@containership.io"),
+			AddedAt: &userTime,
+		},
+	}
 )
 
 func TestNewUsers(t *testing.T) {
@@ -38,6 +46,13 @@ func TestNewUsers(t *testing.T) {
 
 	a = User()
 	assert.NotNil(t, a)
+}
+
+func TestUsersDisableListView(t *testing.T) {
+	a := NewUsers(usersSingle)
+	assert.NotNil(t, a)
+	a.resource.DisableListView()
+	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestUsersTable(t *testing.T) {
@@ -54,4 +69,24 @@ func TestUsersTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(users), info.numRows)
+}
+
+func TestUsersJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewUsers(usersSingle)
+	err := a.JSON(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.JSON(buf)
+	assert.Nil(t, err)
+}
+
+func TestUsersYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewUsers(usersSingle)
+	err := a.YAML(buf)
+	assert.Nil(t, err)
+	a.resource.DisableListView()
+	err = a.YAML(buf)
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?

It can be not to output a json list if getting a single value.

 #### What issue(s) does this fix?
* Fixes #88 

 #### Testing

add TestJSON in template_test.go

##### etc
I think it can be done the same way to a yaml list.
