### PR TITLE
Update cluster name and environment label keys to match new prefix required by the API

### DIFF
--- a/resource/options/cluster_create.go
+++ b/resource/options/cluster_create.go
@@ -63,8 +63,8 @@ func (o *ClusterCreate) DefaultAndValidate() error {
 	}
 
 	o.labels = map[string]string{
-		"containership.io/cluster-name":        o.Name,
-		"containership.io/cluster-environment": o.Environment,
+		"cluster.containership.io/name":        o.Name,
+		"cluster.containership.io/environment": o.Environment,
 	}
 
 	return nil


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
When creating a cluster, send the newly required `cluster.containership.io/name` and `cluster.containership.io/environment` labels as part of the request. This replaces the existing `containership.io/cluster-name` and `containership.io/cluster-environment` labels.

 #### What issue(s) does this fix?
N/A

 #### Additional Considerations
N/A

 ### Testing

 #### Setup
N/A

 #### Instructions
N/A

 ### Dependencies
N/A