### PR TITLE
Default instance size to 2vcpu because kubeadm fails validation on le…

### DIFF
--- a/resource/options/template_create_digitalocean.go
+++ b/resource/options/template_create_digitalocean.go
@@ -102,7 +102,7 @@ func (o *DigitalOceanTemplateCreate) defaultAndValidateRegion() error {
 
 func (o *DigitalOceanTemplateCreate) defaultAndValidateInstanceSize() error {
 	if o.InstanceSize == "" {
-		o.InstanceSize = "s-1vcpu-2gb"
+		o.InstanceSize = "s-2vcpu-2gb"
 	}
 
 	return nil


### PR DESCRIPTION
…ss in newer versions

 ### Description

 #### What does this pull request accomplish?

Defaults digital ocean template creation to `2vcpu`

 #### What issue(s) does this fix?
* n/a
