### PR TITLE
Require clientset for export command

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -23,7 +23,8 @@ var exportCmd = &cobra.Command{
 
 	Args: cobra.ExactArgs(1),
 
-	PreRunE: clusterScopedPreRunE,
+	PersistentPreRunE: clientsetRequiredPreRunE,
+	PreRunE:           clusterScopedPreRunE,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		resource := args[0]
@@ -85,6 +86,7 @@ var exportCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(exportCmd)
 
+	requireClientset(exportCmd)
 	bindCommandToClusterScope(exportCmd, false)
 
 	exportCmd.Flags().StringVarP(&filename, "filename", "f", "", "output kubeconfig to file (default is stdout)")


### PR DESCRIPTION
### Description

 #### What does this pull request accomplish?

Require clientset for export command

Without this, it explodes. Whoops!

 #### What issue(s) does this fix?
 None

 #### Additional Considerations

 ### Testing

`csctl export` doesn't explode

 ### Dependencies
 None