### PR TITLE
disable list view when getting a single element 

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -17,17 +17,17 @@ var (
 	mineOnly     bool
 )
 
-func outputResponse(d resource.Displayable) {
+func outputResponse(d resource.Displayable, listView bool) {
 	var err error
 	switch {
 	case outputFormat == "" || outputFormat == "table":
 		err = d.Table(os.Stdout)
 
 	case outputFormat == "json":
-		err = d.JSON(os.Stdout)
+		err = d.JSON(os.Stdout, listView)
 
 	case outputFormat == "yaml":
-		err = d.YAML(os.Stdout)
+		err = d.YAML(os.Stdout, listView)
 
 	case strings.HasPrefix(outputFormat, "jsonpath"):
 		fields := strings.SplitN(outputFormat, "=", 2)

--- a/cmd/get_access_token.go
+++ b/cmd/get_access_token.go
@@ -32,7 +32,7 @@ var getAccessTokenCmd = &cobra.Command{
 
 		tokens := resource.NewAccessTokens(resp)
 
-		outputResponse(tokens)
+		outputResponse(tokens, len(args) != 1)
 		return nil
 	},
 }

--- a/cmd/get_access_token.go
+++ b/cmd/get_access_token.go
@@ -32,10 +32,6 @@ var getAccessTokenCmd = &cobra.Command{
 
 		tokens := resource.NewAccessTokens(resp)
 
-		if len(args) == 1 {
-			resource.AccessToken().DisableListView()
-		}
-
 		outputResponse(tokens)
 		return nil
 	},

--- a/cmd/get_account.go
+++ b/cmd/get_account.go
@@ -23,8 +23,8 @@ var getAccountCmd = &cobra.Command{
 		}
 
 		accounts := resource.NewAccounts(resp)
-
-		outputResponse(accounts)
+		// this will only ever return one account and should not use list view
+		outputResponse(accounts, false)
 		return nil
 	},
 }

--- a/cmd/get_account.go
+++ b/cmd/get_account.go
@@ -24,10 +24,6 @@ var getAccountCmd = &cobra.Command{
 
 		accounts := resource.NewAccounts(resp)
 
-		if len(args) == 1 {
-			resource.Account().DisableListView()
-		}
-
 		outputResponse(accounts)
 		return nil
 	},

--- a/cmd/get_autoscaling_policy.go
+++ b/cmd/get_autoscaling_policy.go
@@ -46,7 +46,7 @@ var getAutoscalingPolicyCmd = &cobra.Command{
 		}
 
 		nps := resource.NewAutoscalingPolicies(resp)
-		outputResponse(nps)
+		outputResponse(nps, len(args) != 1)
 
 		return nil
 	},

--- a/cmd/get_autoscaling_policy.go
+++ b/cmd/get_autoscaling_policy.go
@@ -46,11 +46,6 @@ var getAutoscalingPolicyCmd = &cobra.Command{
 		}
 
 		nps := resource.NewAutoscalingPolicies(resp)
-
-		if len(args) == 1 {
-			resource.AutoscalingPolicy().DisableListView()
-		}
-
 		outputResponse(nps)
 
 		return nil

--- a/cmd/get_cluster.go
+++ b/cmd/get_cluster.go
@@ -34,10 +34,6 @@ var getClusterCmd = &cobra.Command{
 
 		clusters := resource.NewCKEClusters(resp)
 
-		if len(args) == 1 {
-			resource.CKECluster().DisableListView()
-		}
-
 		if mineOnly {
 			me, err := getMyAccountID()
 			if err != nil {

--- a/cmd/get_cluster.go
+++ b/cmd/get_cluster.go
@@ -43,7 +43,7 @@ var getClusterCmd = &cobra.Command{
 			clusters.FilterByOwnerID(me)
 		}
 
-		outputResponse(clusters)
+		outputResponse(clusters, len(args) != 1)
 		return nil
 	},
 }

--- a/cmd/get_cluster_label.go
+++ b/cmd/get_cluster_label.go
@@ -34,7 +34,7 @@ var getClusterLabelCmd = &cobra.Command{
 
 		labels := resource.NewClusterLabels(resp)
 
-		outputResponse(labels)
+		outputResponse(labels, len(args) != 1)
 
 		return nil
 	},

--- a/cmd/get_cluster_label.go
+++ b/cmd/get_cluster_label.go
@@ -34,10 +34,6 @@ var getClusterLabelCmd = &cobra.Command{
 
 		labels := resource.NewClusterLabels(resp)
 
-		if len(args) == 1 {
-			resource.ClusterLabel().DisableListView()
-		}
-
 		outputResponse(labels)
 
 		return nil

--- a/cmd/get_node.go
+++ b/cmd/get_node.go
@@ -33,7 +33,7 @@ var getNodeCmd = &cobra.Command{
 		}
 
 		nps := resource.NewNodes(resp)
-		outputResponse(nps)
+		outputResponse(nps, len(args) != 1)
 
 		return nil
 	},

--- a/cmd/get_node.go
+++ b/cmd/get_node.go
@@ -33,11 +33,6 @@ var getNodeCmd = &cobra.Command{
 		}
 
 		nps := resource.NewNodes(resp)
-
-		if len(args) == 1 {
-			resource.Node().DisableListView()
-		}
-
 		outputResponse(nps)
 
 		return nil

--- a/cmd/get_node_pool.go
+++ b/cmd/get_node_pool.go
@@ -33,11 +33,6 @@ var getNodePoolCmd = &cobra.Command{
 		}
 
 		nps := resource.NewNodePools(resp)
-
-		if len(args) == 1 {
-			resource.NodePool().DisableListView()
-		}
-
 		outputResponse(nps)
 
 		return nil

--- a/cmd/get_node_pool.go
+++ b/cmd/get_node_pool.go
@@ -33,7 +33,7 @@ var getNodePoolCmd = &cobra.Command{
 		}
 
 		nps := resource.NewNodePools(resp)
-		outputResponse(nps)
+		outputResponse(nps, len(args) != 1)
 
 		return nil
 	},

--- a/cmd/get_node_pool_label.go
+++ b/cmd/get_node_pool_label.go
@@ -34,7 +34,7 @@ var getNodePoolLabelCmd = &cobra.Command{
 
 		labels := resource.NewNodePoolLabels(resp)
 
-		outputResponse(labels)
+		outputResponse(labels, len(args) != 1)
 
 		return nil
 	},

--- a/cmd/get_node_pool_label.go
+++ b/cmd/get_node_pool_label.go
@@ -34,10 +34,6 @@ var getNodePoolLabelCmd = &cobra.Command{
 
 		labels := resource.NewNodePoolLabels(resp)
 
-		if len(args) == 1 {
-			resource.NodePoolLabel().DisableListView()
-		}
-
 		outputResponse(labels)
 
 		return nil

--- a/cmd/get_organization.go
+++ b/cmd/get_organization.go
@@ -41,7 +41,7 @@ var getOrganizationCmd = &cobra.Command{
 			orgs.FilterByOwnerID(me)
 		}
 
-		outputResponse(orgs)
+		outputResponse(orgs, len(args) != 1)
 		return nil
 	},
 }

--- a/cmd/get_organization.go
+++ b/cmd/get_organization.go
@@ -32,10 +32,6 @@ var getOrganizationCmd = &cobra.Command{
 
 		orgs := resource.NewOrganizations(resp)
 
-		if len(args) == 1 {
-			resource.Organization().DisableListView()
-		}
-
 		if mineOnly {
 			me, err := getMyAccountID()
 			if err != nil {

--- a/cmd/get_plugin.go
+++ b/cmd/get_plugin.go
@@ -33,7 +33,7 @@ var getPluginCmd = &cobra.Command{
 		}
 
 		plugs := resource.NewPlugins(resp)
-		outputResponse(plugs)
+		outputResponse(plugs, len(args) != 1)
 		return nil
 	},
 }

--- a/cmd/get_plugin.go
+++ b/cmd/get_plugin.go
@@ -33,11 +33,6 @@ var getPluginCmd = &cobra.Command{
 		}
 
 		plugs := resource.NewPlugins(resp)
-
-		if len(args) == 1 {
-			resource.Plugin().DisableListView()
-		}
-
 		outputResponse(plugs)
 		return nil
 	},

--- a/cmd/get_plugin_catalog.go
+++ b/cmd/get_plugin_catalog.go
@@ -65,7 +65,7 @@ var getPluginCatalogCmd = &cobra.Command{
 			return errors.New("invalid flag combination - see usage")
 		}
 
-		outputResponse(plugins)
+		outputResponse(plugins, false)
 		return nil
 	},
 }

--- a/cmd/get_plugin_catalog.go
+++ b/cmd/get_plugin_catalog.go
@@ -65,10 +65,6 @@ var getPluginCatalogCmd = &cobra.Command{
 			return errors.New("invalid flag combination - see usage")
 		}
 
-		if len(args) == 1 {
-			resource.PluginCatalog().DisableListView()
-		}
-
 		outputResponse(plugins)
 		return nil
 	},

--- a/cmd/get_provider.go
+++ b/cmd/get_provider.go
@@ -34,10 +34,6 @@ var getProviderCmd = &cobra.Command{
 
 		providers := resource.NewProviders(resp)
 
-		if len(args) == 1 {
-			resource.Provider().DisableListView()
-		}
-
 		outputResponse(providers)
 		return nil
 	},

--- a/cmd/get_provider.go
+++ b/cmd/get_provider.go
@@ -34,7 +34,7 @@ var getProviderCmd = &cobra.Command{
 
 		providers := resource.NewProviders(resp)
 
-		outputResponse(providers)
+		outputResponse(providers, len(args) != 1)
 		return nil
 	},
 }

--- a/cmd/get_registry.go
+++ b/cmd/get_registry.go
@@ -33,7 +33,8 @@ var getRegistryCmd = &cobra.Command{
 		}
 
 		regs := resource.NewRegistries(resp)
-		outputResponse(regs)
+
+		outputResponse(regs, len(args) != 1)
 		return nil
 	},
 }

--- a/cmd/get_registry.go
+++ b/cmd/get_registry.go
@@ -33,11 +33,6 @@ var getRegistryCmd = &cobra.Command{
 		}
 
 		regs := resource.NewRegistries(resp)
-
-		if len(args) == 1 {
-			resource.Registry().DisableListView()
-		}
-
 		outputResponse(regs)
 		return nil
 	},

--- a/cmd/get_template.go
+++ b/cmd/get_template.go
@@ -34,10 +34,6 @@ var getTemplateCmd = &cobra.Command{
 
 		templates := resource.NewTemplates(resp)
 
-		if len(args) == 1 {
-			resource.Template().DisableListView()
-		}
-
 		if mineOnly {
 			me, err := getMyAccountID()
 			if err != nil {

--- a/cmd/get_template.go
+++ b/cmd/get_template.go
@@ -47,7 +47,7 @@ var getTemplateCmd = &cobra.Command{
 		// since consumers should never care about non-CKE clusters.
 		templates.FilterByEngine(types.TemplateEngineContainershipKubernetesEngine)
 
-		outputResponse(templates)
+		outputResponse(templates, len(args) != 1)
 		return nil
 	},
 }

--- a/cmd/get_user.go
+++ b/cmd/get_user.go
@@ -26,7 +26,7 @@ var getUserCmd = &cobra.Command{
 
 		users := resource.NewUsers(resp)
 
-		outputResponse(users)
+		outputResponse(users, true)
 		return nil
 	},
 }

--- a/cmd/get_user.go
+++ b/cmd/get_user.go
@@ -26,10 +26,6 @@ var getUserCmd = &cobra.Command{
 
 		users := resource.NewUsers(resp)
 
-		if len(args) == 1 {
-			resource.User().DisableListView()
-		}
-
 		outputResponse(users)
 		return nil
 	},

--- a/resource/access_tokens.go
+++ b/resource/access_tokens.go
@@ -19,10 +19,9 @@ type AccessTokens struct {
 func NewAccessTokens(items []types.AccessToken) *AccessTokens {
 	return &AccessTokens{
 		resource: resource{
-			name:     "access-token",
-			plural:   "access-tokens",
-			aliases:  []string{"token", "tokens"},
-			listView: true,
+			name:    "access-token",
+			plural:  "access-tokens",
+			aliases: []string{"token", "tokens"},
 		},
 		items: items,
 	}
@@ -61,12 +60,12 @@ func (t *AccessTokens) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (t *AccessTokens) JSON(w io.Writer) error {
-	return displayJSON(w, t.items, t.resource.listView)
+	return displayJSON(w, t.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (t *AccessTokens) YAML(w io.Writer) error {
-	return displayYAML(w, t.items, t.resource.listView)
+	return displayYAML(w, t.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/access_tokens.go
+++ b/resource/access_tokens.go
@@ -59,12 +59,20 @@ func (t *AccessTokens) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (t *AccessTokens) JSON(w io.Writer) error {
+func (t *AccessTokens) JSON(w io.Writer, listView bool) error {
+	if !listView && len(t.items) == 1 {
+		return displayJSON(w, t.items[0])
+	}
+
 	return displayJSON(w, t.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (t *AccessTokens) YAML(w io.Writer) error {
+func (t *AccessTokens) YAML(w io.Writer, listView bool) error {
+	if !listView && len(t.items) == 1 {
+		return displayYAML(w, t.items[0])
+	}
+
 	return displayYAML(w, t.items)
 }
 

--- a/resource/accounts.go
+++ b/resource/accounts.go
@@ -18,9 +18,8 @@ type Accounts struct {
 func NewAccounts(items []types.Account) *Accounts {
 	return &Accounts{
 		resource: resource{
-			name:     "account",
-			aliases:  []string{"acct"},
-			listView: true,
+			name:    "account",
+			aliases: []string{"acct"},
 		},
 		items: items,
 	}
@@ -59,12 +58,12 @@ func (a *Accounts) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (a *Accounts) JSON(w io.Writer) error {
-	return displayJSON(w, a.items, a.resource.listView)
+	return displayJSON(w, a.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (a *Accounts) YAML(w io.Writer) error {
-	return displayYAML(w, a.items, a.resource.listView)
+	return displayYAML(w, a.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/accounts.go
+++ b/resource/accounts.go
@@ -57,12 +57,20 @@ func (a *Accounts) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (a *Accounts) JSON(w io.Writer) error {
+func (a *Accounts) JSON(w io.Writer, listView bool) error {
+	if !listView && len(a.items) == 1 {
+		return displayJSON(w, a.items[0])
+	}
+
 	return displayJSON(w, a.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (a *Accounts) YAML(w io.Writer) error {
+func (a *Accounts) YAML(w io.Writer, listView bool) error {
+	if !listView && len(a.items) == 1 {
+		return displayYAML(w, a.items[0])
+	}
+
 	return displayYAML(w, a.items)
 }
 

--- a/resource/accounts_test.go
+++ b/resource/accounts_test.go
@@ -24,13 +24,6 @@ var (
 			CreatedAt: &acctTime,
 		},
 	}
-	acctSingle = []types.Account{
-		{
-			Name:      strptr("test3"),
-			ID:        types.UUID("1234"),
-			CreatedAt: &acctTime,
-		},
-	}
 )
 
 func TestNewAccounts(t *testing.T) {
@@ -43,13 +36,6 @@ func TestNewAccounts(t *testing.T) {
 
 	a = Account()
 	assert.NotNil(t, a)
-}
-
-func TestAccountsDisableListView(t *testing.T) {
-	a := NewAccounts(nil)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestAccountsTable(t *testing.T) {
@@ -66,24 +52,4 @@ func TestAccountsTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(accts), info.numRows)
-}
-
-func TestAccountsJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewAccounts(acctSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestAccountsYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewAccounts(acctSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
 }

--- a/resource/accounts_test.go
+++ b/resource/accounts_test.go
@@ -24,7 +24,35 @@ var (
 			CreatedAt: &acctTime,
 		},
 	}
+
+	acctSingle = []types.Account{
+		{
+			Name:      strptr("test3"),
+			ID:        types.UUID("1234"),
+			CreatedAt: &acctTime,
+		},
+	}
 )
+
+func TestAccountsJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewAccounts(acctSingle)
+	err := a.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = a.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestAccountsYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewAccounts(acctSingle)
+	err := a.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = a.YAML(buf, false)
+	assert.Nil(t, err)
+}
 
 func TestNewAccounts(t *testing.T) {
 	a := NewAccounts(nil)

--- a/resource/autoscaling_policies.go
+++ b/resource/autoscaling_policies.go
@@ -98,12 +98,20 @@ func getPolicyConfiguration(config *types.ScalingPolicyConfiguration, scaleDown 
 }
 
 // JSON outputs the JSON representation to the given writer
-func (p *AutoscalingPolicies) JSON(w io.Writer) error {
+func (p *AutoscalingPolicies) JSON(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayJSON(w, p.items[0])
+	}
+
 	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (p *AutoscalingPolicies) YAML(w io.Writer) error {
+func (p *AutoscalingPolicies) YAML(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayYAML(w, p.items[0])
+	}
+
 	return displayYAML(w, p.items)
 }
 

--- a/resource/autoscaling_policies.go
+++ b/resource/autoscaling_policies.go
@@ -18,10 +18,9 @@ type AutoscalingPolicies struct {
 func NewAutoscalingPolicies(items []types.AutoscalingPolicy) *AutoscalingPolicies {
 	return &AutoscalingPolicies{
 		resource: resource{
-			name:     "autoscaling-policy",
-			plural:   "autoscaling-policies",
-			aliases:  []string{"asp", "asps"},
-			listView: true,
+			name:    "autoscaling-policy",
+			plural:  "autoscaling-policies",
+			aliases: []string{"asp", "asps"},
 		},
 		items: items,
 	}
@@ -100,12 +99,12 @@ func getPolicyConfiguration(config *types.ScalingPolicyConfiguration, scaleDown 
 
 // JSON outputs the JSON representation to the given writer
 func (p *AutoscalingPolicies) JSON(w io.Writer) error {
-	return displayJSON(w, p.items, p.resource.listView)
+	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *AutoscalingPolicies) YAML(w io.Writer) error {
-	return displayYAML(w, p.items, p.resource.listView)
+	return displayYAML(w, p.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/autoscaling_policies_test.go
+++ b/resource/autoscaling_policies_test.go
@@ -65,30 +65,6 @@ var (
 			SamplePeriod:   int32ptr(800),
 		},
 	}
-	aspsSingle = []types.AutoscalingPolicy{
-		{
-			Name:           strptr("test4"),
-			ID:             types.UUID("1234"),
-			MetricsBackend: "prometheus",
-			Metric:         strptr("cpu"),
-			ScalingPolicy: &types.ScalingPolicy{
-				ScaleUp: &types.ScalingPolicyConfiguration{
-					AdjustmentType:     strptr("percent"),
-					AdjustmentValue:    float32ptr(10),
-					ComparisonOperator: strptr(">="),
-					Threshold:          float32ptr(0.5),
-				},
-				ScaleDown: &types.ScalingPolicyConfiguration{
-					AdjustmentType:     strptr("percent"),
-					AdjustmentValue:    float32ptr(30),
-					ComparisonOperator: strptr("<"),
-					Threshold:          float32ptr(0.3),
-				},
-			},
-			PollInterval: int32ptr(15),
-			SamplePeriod: int32ptr(600),
-		},
-	}
 )
 
 func TestNewAutoscalingPolicies(t *testing.T) {
@@ -101,13 +77,6 @@ func TestNewAutoscalingPolicies(t *testing.T) {
 
 	a = AutoscalingPolicy()
 	assert.NotNil(t, a)
-}
-
-func TestAutoscalingPoliciesDisableListView(t *testing.T) {
-	a := NewAutoscalingPolicies(aspsSingle)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestAutoscalingPoliciesTable(t *testing.T) {
@@ -124,24 +93,4 @@ func TestAutoscalingPoliciesTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(asps), info.numRows)
-}
-
-func TestAutoscalingPoliciesJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewAutoscalingPolicies(aspsSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestAutoscalingPoliciesYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewAutoscalingPolicies(aspsSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
 }

--- a/resource/autoscaling_policies_test.go
+++ b/resource/autoscaling_policies_test.go
@@ -65,7 +65,52 @@ var (
 			SamplePeriod:   int32ptr(800),
 		},
 	}
+
+	aspsSingle = []types.AutoscalingPolicy{
+		{
+			Name:           strptr("test4"),
+			ID:             types.UUID("1234"),
+			MetricsBackend: "prometheus",
+			Metric:         strptr("cpu"),
+			ScalingPolicy: &types.ScalingPolicy{
+				ScaleUp: &types.ScalingPolicyConfiguration{
+					AdjustmentType:     strptr("percent"),
+					AdjustmentValue:    float32ptr(10),
+					ComparisonOperator: strptr(">="),
+					Threshold:          float32ptr(0.5),
+				},
+				ScaleDown: &types.ScalingPolicyConfiguration{
+					AdjustmentType:     strptr("percent"),
+					AdjustmentValue:    float32ptr(30),
+					ComparisonOperator: strptr("<"),
+					Threshold:          float32ptr(0.3),
+				},
+			},
+			PollInterval: int32ptr(15),
+			SamplePeriod: int32ptr(600),
+		},
+	}
 )
+
+func TestAutoscalingPoliciesJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewAutoscalingPolicies(aspsSingle)
+	err := a.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = a.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestAutoscalingPoliciesYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewAutoscalingPolicies(aspsSingle)
+	err := a.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = a.YAML(buf, false)
+	assert.Nil(t, err)
+}
 
 func TestNewAutoscalingPolicies(t *testing.T) {
 	a := NewAutoscalingPolicies(nil)

--- a/resource/cke_clusters.go
+++ b/resource/cke_clusters.go
@@ -62,12 +62,20 @@ func (c *CKEClusters) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (c *CKEClusters) JSON(w io.Writer) error {
+func (c *CKEClusters) JSON(w io.Writer, listView bool) error {
+	if !listView && len(c.items) == 1 {
+		return displayJSON(w, c.items[0])
+	}
+
 	return displayJSON(w, c.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (c *CKEClusters) YAML(w io.Writer) error {
+func (c *CKEClusters) YAML(w io.Writer, listView bool) error {
+	if !listView && len(c.items) == 1 {
+		return displayYAML(w, c.items[0])
+	}
+
 	return displayYAML(w, c.items)
 }
 

--- a/resource/cke_clusters.go
+++ b/resource/cke_clusters.go
@@ -19,9 +19,8 @@ type CKEClusters struct {
 func NewCKEClusters(items []types.CKECluster) *CKEClusters {
 	return &CKEClusters{
 		resource: resource{
-			name:     "cluster",
-			plural:   "clusters",
-			listView: true,
+			name:   "cluster",
+			plural: "clusters",
 		},
 		items: items,
 	}
@@ -64,12 +63,12 @@ func (c *CKEClusters) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (c *CKEClusters) JSON(w io.Writer) error {
-	return displayJSON(w, c.items, c.resource.listView)
+	return displayJSON(w, c.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (c *CKEClusters) YAML(w io.Writer) error {
-	return displayYAML(w, c.items, c.resource.listView)
+	return displayYAML(w, c.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/cke_clusters_test.go
+++ b/resource/cke_clusters_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/containership/csctl/cloud/provision/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/containership/csctl/cloud/provision/types"
 )
 
 var (
@@ -31,17 +32,6 @@ var (
 			CreatedAt: &ckeClusterTime,
 		},
 	}
-	ckeClusterSingle = []types.CKECluster{
-		{
-			ID:           types.UUID("1111"),
-			ProviderName: strptr("google"),
-			Status: &types.CKEClusterStatus{
-				Type: strptr("RUNNING"),
-			},
-			OwnerID:   types.UUID("1111"),
-			CreatedAt: &ckeClusterTime,
-		},
-	}
 )
 
 func TestNewCKEClusters(t *testing.T) {
@@ -54,13 +44,6 @@ func TestNewCKEClusters(t *testing.T) {
 
 	a = CKECluster()
 	assert.NotNil(t, a)
-}
-
-func TestCKEClustersDisableListView(t *testing.T) {
-	a := NewCKEClusters(nil)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestCKEClustersTable(t *testing.T) {
@@ -77,24 +60,4 @@ func TestCKEClustersTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(ckeClusters), info.numRows)
-}
-
-func TestCKEClustersJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cluster := NewCKEClusters(ckeClusterSingle)
-	err := cluster.JSON(buf)
-	assert.Nil(t, err)
-	cluster.resource.DisableListView()
-	err = cluster.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestCKEClustersYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cluster := NewCKEClusters(ckeClusterSingle)
-	err := cluster.YAML(buf)
-	assert.Nil(t, err)
-	cluster.resource.DisableListView()
-	err = cluster.YAML(buf)
-	assert.Nil(t, err)
 }

--- a/resource/cke_clusters_test.go
+++ b/resource/cke_clusters_test.go
@@ -32,7 +32,39 @@ var (
 			CreatedAt: &ckeClusterTime,
 		},
 	}
+
+	ckeClusterSingle = []types.CKECluster{
+		{
+			ID:           types.UUID("1111"),
+			ProviderName: strptr("google"),
+			Status: &types.CKEClusterStatus{
+				Type: strptr("RUNNING"),
+			},
+			OwnerID:   types.UUID("1111"),
+			CreatedAt: &ckeClusterTime,
+		},
+	}
 )
+
+func TestCKEClustersJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	cluster := NewCKEClusters(ckeClusterSingle)
+	err := cluster.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = cluster.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestCKEClustersYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	cluster := NewCKEClusters(ckeClusterSingle)
+	err := cluster.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = cluster.YAML(buf, false)
+	assert.Nil(t, err)
+}
 
 func TestNewCKEClusters(t *testing.T) {
 	a := NewCKEClusters(nil)

--- a/resource/cluster_labels.go
+++ b/resource/cluster_labels.go
@@ -62,12 +62,12 @@ func (p *ClusterLabels) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (p *ClusterLabels) JSON(w io.Writer) error {
-	return displayJSON(w, p.items, p.listView)
+	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *ClusterLabels) YAML(w io.Writer) error {
-	return displayYAML(w, p.items, p.listView)
+	return displayYAML(w, p.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/cluster_labels.go
+++ b/resource/cluster_labels.go
@@ -61,12 +61,20 @@ func (p *ClusterLabels) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (p *ClusterLabels) JSON(w io.Writer) error {
+func (p *ClusterLabels) JSON(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayJSON(w, p.items[0])
+	}
+
 	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (p *ClusterLabels) YAML(w io.Writer) error {
+func (p *ClusterLabels) YAML(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayYAML(w, p.items[0])
+	}
+
 	return displayYAML(w, p.items)
 }
 

--- a/resource/cluster_labels_test.go
+++ b/resource/cluster_labels_test.go
@@ -68,26 +68,6 @@ func TestClusterLabelsTable(t *testing.T) {
 	assert.Equal(t, len(nodes), info.numRows)
 }
 
-func TestClusterLabelsJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewClusterLabels(clusterLabelsSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestClusterLabelsYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewClusterLabels(clusterLabelsSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
-}
-
 func TestBuildClusterLabelString(t *testing.T) {
 	type stringTest struct {
 		label    types.ClusterLabel

--- a/resource/cluster_labels_test.go
+++ b/resource/cluster_labels_test.go
@@ -40,6 +40,26 @@ var (
 	}
 )
 
+func TestClusterLabelsJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewClusterLabels(clusterLabelsSingle)
+	err := a.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = a.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestClusterLabelsYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewClusterLabels(clusterLabelsSingle)
+	err := a.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = a.YAML(buf, false)
+	assert.Nil(t, err)
+}
+
 func TestNewClusterLabels(t *testing.T) {
 	a := NewNodes(nil)
 	assert.NotNil(t, a)

--- a/resource/display.go
+++ b/resource/display.go
@@ -16,8 +16,8 @@ type Displayable interface {
 	columns() []string
 
 	Table(w io.Writer) error
-	JSON(w io.Writer) error
-	YAML(w io.Writer) error
+	JSON(w io.Writer, listView bool) error
+	YAML(w io.Writer, listView bool) error
 	JSONPath(w io.Writer, template string) error
 }
 

--- a/resource/display.go
+++ b/resource/display.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/containership/csctl/cloud/provision/types"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/util/jsonpath"
@@ -22,18 +21,8 @@ type Displayable interface {
 	JSONPath(w io.Writer, template string) error
 }
 
-func assertTypes(data interface{}, listView bool) interface{} {
-	switch val := data.(type) {
-	case []types.Template:
-		if len(val) == 1 && !listView {
-			return val[1:]
-		}
-	}
-	return data
-}
-
-func displayJSON(w io.Writer, data interface{}, listView bool) error {
-	j, err := json.MarshalIndent(assertTypes(data, listView), "", "  ")
+func displayJSON(w io.Writer, data interface{}) error {
+	j, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return errors.Wrap(err, "marshaling to JSON")
 	}
@@ -43,8 +32,8 @@ func displayJSON(w io.Writer, data interface{}, listView bool) error {
 	return nil
 }
 
-func displayYAML(w io.Writer, data interface{}, listView bool) error {
-	j, err := json.Marshal(assertTypes(data, listView))
+func displayYAML(w io.Writer, data interface{}) error {
+	j, err := json.Marshal(data)
 	if err != nil {
 		return errors.Wrap(err, "marshaling to JSON")
 	}

--- a/resource/node_pool_labels.go
+++ b/resource/node_pool_labels.go
@@ -62,12 +62,12 @@ func (p *NodePoolLabels) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (p *NodePoolLabels) JSON(w io.Writer) error {
-	return displayJSON(w, p.items, p.listView)
+	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *NodePoolLabels) YAML(w io.Writer) error {
-	return displayYAML(w, p.items, p.listView)
+	return displayYAML(w, p.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/node_pool_labels.go
+++ b/resource/node_pool_labels.go
@@ -61,12 +61,20 @@ func (p *NodePoolLabels) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (p *NodePoolLabels) JSON(w io.Writer) error {
+func (p *NodePoolLabels) JSON(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayJSON(w, p.items[0])
+	}
+
 	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (p *NodePoolLabels) YAML(w io.Writer) error {
+func (p *NodePoolLabels) YAML(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayYAML(w, p.items[0])
+	}
+
 	return displayYAML(w, p.items)
 }
 

--- a/resource/node_pool_labels_test.go
+++ b/resource/node_pool_labels_test.go
@@ -52,6 +52,26 @@ func TestNewNodePoolLabels(t *testing.T) {
 	assert.NotNil(t, a)
 }
 
+func TestNodePoolLabelsJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewNodePoolLabels(nodePoolLabelsSingle)
+	err := a.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = a.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestNodePoolLabelsYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewNodePoolLabels(nodePoolLabelsSingle)
+	err := a.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = a.YAML(buf, false)
+	assert.Nil(t, err)
+}
+
 func TestNodePoolLabelsTable(t *testing.T) {
 	buf := new(bytes.Buffer)
 

--- a/resource/node_pool_labels_test.go
+++ b/resource/node_pool_labels_test.go
@@ -68,26 +68,6 @@ func TestNodePoolLabelsTable(t *testing.T) {
 	assert.Equal(t, len(nodes), info.numRows)
 }
 
-func TestNodePoolLabelsJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewNodePoolLabels(nodePoolLabelsSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestNodePoolLabelsYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewNodePoolLabels(nodePoolLabelsSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
-}
-
 func TestBuildNodePoolLabelString(t *testing.T) {
 	type stringTest struct {
 		label    types.NodePoolLabel

--- a/resource/node_pools.go
+++ b/resource/node_pools.go
@@ -17,10 +17,9 @@ type NodePools struct {
 func NewNodePools(items []types.NodePool) *NodePools {
 	return &NodePools{
 		resource: resource{
-			name:     "node-pool",
-			plural:   "node-pools",
-			aliases:  []string{"nodepool", "nodepools", "np", "nps"},
-			listView: true,
+			name:    "node-pool",
+			plural:  "node-pools",
+			aliases: []string{"nodepool", "nodepools", "np", "nps"},
 		},
 		items: items,
 	}
@@ -82,12 +81,12 @@ func (p *NodePools) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (p *NodePools) JSON(w io.Writer) error {
-	return displayJSON(w, p.items, p.resource.listView)
+	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *NodePools) YAML(w io.Writer) error {
-	return displayYAML(w, p.items, p.resource.listView)
+	return displayYAML(w, p.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/node_pools.go
+++ b/resource/node_pools.go
@@ -80,12 +80,20 @@ func (p *NodePools) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (p *NodePools) JSON(w io.Writer) error {
+func (p *NodePools) JSON(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayJSON(w, p.items[0])
+	}
+
 	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (p *NodePools) YAML(w io.Writer) error {
+func (p *NodePools) YAML(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayYAML(w, p.items[0])
+	}
+
 	return displayYAML(w, p.items)
 }
 

--- a/resource/node_pools_test.go
+++ b/resource/node_pools_test.go
@@ -31,16 +31,6 @@ var (
 			DockerVersion:     &dockerVersion,
 		},
 	}
-	npsSingle = []types.NodePool{
-		{
-			Name:              strptr("test3"),
-			ID:                types.UUID("1234"),
-			KubernetesMode:    strptr("master"),
-			KubernetesVersion: strptr("1.12.1"),
-			EtcdVersion:       &etcdVersion,
-			DockerVersion:     &dockerVersion,
-		},
-	}
 )
 
 func TestNewNodePools(t *testing.T) {
@@ -53,13 +43,6 @@ func TestNewNodePools(t *testing.T) {
 
 	a = NodePool()
 	assert.NotNil(t, a)
-}
-
-func TestNodePoolsDisableListView(t *testing.T) {
-	a := NewNodePools(npsSingle)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestNodePoolsTable(t *testing.T) {
@@ -76,24 +59,4 @@ func TestNodePoolsTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(nps), info.numRows)
-}
-
-func TestNodePoolsJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewNodePools(npsSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestNodePoolsYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewNodePools(npsSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
 }

--- a/resource/node_pools_test.go
+++ b/resource/node_pools_test.go
@@ -31,7 +31,38 @@ var (
 			DockerVersion:     &dockerVersion,
 		},
 	}
+
+	npsSingle = []types.NodePool{
+		{
+			Name:              strptr("test3"),
+			ID:                types.UUID("1234"),
+			KubernetesMode:    strptr("master"),
+			KubernetesVersion: strptr("1.12.1"),
+			EtcdVersion:       &etcdVersion,
+			DockerVersion:     &dockerVersion,
+		},
+	}
 )
+
+func TestNodePoolsJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewNodePools(npsSingle)
+	err := a.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = a.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestNodePoolsYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewNodePools(npsSingle)
+	err := a.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = a.YAML(buf, false)
+	assert.Nil(t, err)
+}
 
 func TestNewNodePools(t *testing.T) {
 	a := NewNodePools(nil)

--- a/resource/nodes.go
+++ b/resource/nodes.go
@@ -18,10 +18,9 @@ type Nodes struct {
 func NewNodes(items []types.Node) *Nodes {
 	return &Nodes{
 		resource: resource{
-			name:     "node",
-			plural:   "nodes",
-			aliases:  []string{"no", "nos"},
-			listView: true,
+			name:    "node",
+			plural:  "nodes",
+			aliases: []string{"no", "nos"},
 		},
 		items: items,
 	}
@@ -70,12 +69,12 @@ func (p *Nodes) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (p *Nodes) JSON(w io.Writer) error {
-	return displayJSON(w, p.items, p.resource.listView)
+	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *Nodes) YAML(w io.Writer) error {
-	return displayYAML(w, p.items, p.resource.listView)
+	return displayYAML(w, p.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/nodes.go
+++ b/resource/nodes.go
@@ -68,12 +68,20 @@ func (p *Nodes) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (p *Nodes) JSON(w io.Writer) error {
+func (p *Nodes) JSON(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayJSON(w, p.items[0])
+	}
+
 	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (p *Nodes) YAML(w io.Writer) error {
+func (p *Nodes) YAML(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayYAML(w, p.items[0])
+	}
+
 	return displayYAML(w, p.items)
 }
 

--- a/resource/nodes_test.go
+++ b/resource/nodes_test.go
@@ -30,7 +30,38 @@ var (
 			UpdatedAt: &nodeTime,
 		},
 	}
+
+	nodesSingle = []types.Node{
+		{
+			ID: types.UUID("1234"),
+			Status: &types.NodeStatus{
+				Type: strptr("RUNNING"),
+			},
+			CreatedAt: &nodeTime,
+			UpdatedAt: &nodeTime,
+		},
+	}
 )
+
+func TestNodesJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewNodes(nodesSingle)
+	err := a.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = a.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestNodesYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewNodes(nodesSingle)
+	err := a.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = a.YAML(buf, false)
+	assert.Nil(t, err)
+}
 
 func TestNewNodes(t *testing.T) {
 	a := NewNodes(nil)

--- a/resource/nodes_test.go
+++ b/resource/nodes_test.go
@@ -30,16 +30,6 @@ var (
 			UpdatedAt: &nodeTime,
 		},
 	}
-	nodesSingle = []types.Node{
-		{
-			ID: types.UUID("1234"),
-			Status: &types.NodeStatus{
-				Type: strptr("RUNNING"),
-			},
-			CreatedAt: &nodeTime,
-			UpdatedAt: &nodeTime,
-		},
-	}
 )
 
 func TestNewNodes(t *testing.T) {
@@ -52,13 +42,6 @@ func TestNewNodes(t *testing.T) {
 
 	a = Node()
 	assert.NotNil(t, a)
-}
-
-func TestNodesDisableListView(t *testing.T) {
-	a := NewNodes(nodesSingle)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestNodesTable(t *testing.T) {
@@ -75,24 +58,4 @@ func TestNodesTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(nodes), info.numRows)
-}
-
-func TestNodesJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewNodes(nodesSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestNodesYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewNodes(nodesSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
 }

--- a/resource/organizations.go
+++ b/resource/organizations.go
@@ -61,12 +61,20 @@ func (o *Organizations) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (o *Organizations) JSON(w io.Writer) error {
+func (o *Organizations) JSON(w io.Writer, listView bool) error {
+	if !listView && len(o.items) == 1 {
+		return displayJSON(w, o.items[0])
+	}
+
 	return displayJSON(w, o.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (o *Organizations) YAML(w io.Writer) error {
+func (o *Organizations) YAML(w io.Writer, listView bool) error {
+	if !listView && len(o.items) == 1 {
+		return displayYAML(w, o.items[0])
+	}
+
 	return displayYAML(w, o.items)
 }
 

--- a/resource/organizations.go
+++ b/resource/organizations.go
@@ -19,10 +19,9 @@ type Organizations struct {
 func NewOrganizations(items []types.Organization) *Organizations {
 	return &Organizations{
 		resource: resource{
-			name:     "organization",
-			plural:   "organizations",
-			aliases:  []string{"org", "orgs"},
-			listView: true,
+			name:    "organization",
+			plural:  "organizations",
+			aliases: []string{"org", "orgs"},
 		},
 		items: items,
 	}
@@ -63,12 +62,12 @@ func (o *Organizations) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (o *Organizations) JSON(w io.Writer) error {
-	return displayJSON(w, o.items, o.resource.listView)
+	return displayJSON(w, o.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (o *Organizations) YAML(w io.Writer) error {
-	return displayYAML(w, o.items, o.resource.listView)
+	return displayYAML(w, o.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/organizations_test.go
+++ b/resource/organizations_test.go
@@ -26,7 +26,36 @@ var (
 			CreatedAt: &orgTime,
 		},
 	}
+
+	orgsSingle = []types.Organization{
+		{
+			Name:      strptr("test3"),
+			ID:        types.UUID("1234"),
+			OwnerID:   types.UUID("1234"),
+			CreatedAt: &orgTime,
+		},
+	}
 )
+
+func TestOrganizationsJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewOrganizations(orgsSingle)
+	err := a.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = a.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestOrganizationsYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewOrganizations(orgsSingle)
+	err := a.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = a.YAML(buf, false)
+	assert.Nil(t, err)
+}
 
 func TestNewOrganizations(t *testing.T) {
 	a := NewOrganizations(nil)

--- a/resource/organizations_test.go
+++ b/resource/organizations_test.go
@@ -26,14 +26,6 @@ var (
 			CreatedAt: &orgTime,
 		},
 	}
-	orgsSingle = []types.Organization{
-		{
-			Name:      strptr("test3"),
-			ID:        types.UUID("1234"),
-			OwnerID:   types.UUID("1234"),
-			CreatedAt: &orgTime,
-		},
-	}
 )
 
 func TestNewOrganizations(t *testing.T) {
@@ -46,13 +38,6 @@ func TestNewOrganizations(t *testing.T) {
 
 	a = Organization()
 	assert.NotNil(t, a)
-}
-
-func TestOrganizationsDisableListView(t *testing.T) {
-	a := NewOrganizations(orgsSingle)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestOrganizationsTable(t *testing.T) {
@@ -69,24 +54,4 @@ func TestOrganizationsTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(orgs), info.numRows)
-}
-
-func TestOrganizationsJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewOrganizations(orgsSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestOrganizationsYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewOrganizations(orgsSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
 }

--- a/resource/plugin_catalog.go
+++ b/resource/plugin_catalog.go
@@ -17,9 +17,8 @@ type PluginsCatalog struct {
 func NewPluginCatalog(item *types.PluginCatalog) *PluginsCatalog {
 	return &PluginsCatalog{
 		resource: resource{
-			name:     "plugin-catalog",
-			aliases:  []string{"plgnc", "plugc", "pc"},
-			listView: true,
+			name:    "plugin-catalog",
+			aliases: []string{"plgnc", "plugc", "pc"},
 		},
 		items: item,
 	}
@@ -122,12 +121,12 @@ func (pc *PluginsCatalog) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (pc *PluginsCatalog) JSON(w io.Writer) error {
-	return displayJSON(w, pc.items, pc.resource.listView)
+	return displayJSON(w, pc.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (pc *PluginsCatalog) YAML(w io.Writer) error {
-	return displayYAML(w, pc.items, pc.resource.listView)
+	return displayYAML(w, pc.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/plugin_catalog.go
+++ b/resource/plugin_catalog.go
@@ -120,12 +120,12 @@ func (pc *PluginsCatalog) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (pc *PluginsCatalog) JSON(w io.Writer) error {
+func (pc *PluginsCatalog) JSON(w io.Writer, _ bool) error {
 	return displayJSON(w, pc.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (pc *PluginsCatalog) YAML(w io.Writer) error {
+func (pc *PluginsCatalog) YAML(w io.Writer, _ bool) error {
 	return displayYAML(w, pc.items)
 }
 

--- a/resource/plugin_catalog_test.go
+++ b/resource/plugin_catalog_test.go
@@ -131,31 +131,6 @@ var (
 			},
 		},
 	}
-	plugsCatalogSingle = &types.PluginCatalog{
-		Autoscaler: []*types.PluginDefinition{
-			{
-				Implementation: strptr("cerebral"),
-				Versions: []*types.PluginVersion{
-					{
-						Version: strptr("1.0.0"),
-						Compatibility: &types.PluginCompatibility{
-							Kubernetes: &types.PluginKubernetesCompatibility{
-								Min: strptr("1.10.x"),
-								Max: strptr("1.12.x"),
-							},
-							Plugins: map[string]types.PluginPluginsCompatibility{
-								"Metrics": {
-									Implementation: strptr("prometheus"),
-									Min:            strptr("1.0.0"),
-									Max:            strptr("1.1.0"),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 )
 
 func TestNewPluginCatalog(t *testing.T) {
@@ -168,13 +143,6 @@ func TestNewPluginCatalog(t *testing.T) {
 
 	pc = PluginCatalog()
 	assert.NotNil(t, pc)
-}
-
-func TestPluginCatalogsDisableListView(t *testing.T) {
-	a := NewPluginCatalog(plugsCatalogSingle)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestNewPluginCatalogFromDefinition(t *testing.T) {
@@ -246,24 +214,4 @@ func TestPluginCatalogTable(t *testing.T) {
 	l += len(plugsCatalog.Metrics)
 
 	assert.Equal(t, l, info.numRows)
-}
-
-func TestPluginCatalogJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewPluginCatalog(plugsCatalogSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestPluginCatalogYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewPluginCatalog(plugsCatalogSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
 }

--- a/resource/plugins.go
+++ b/resource/plugins.go
@@ -19,10 +19,9 @@ type Plugins struct {
 func NewPlugins(items []types.Plugin) *Plugins {
 	return &Plugins{
 		resource: resource{
-			name:     "plugin",
-			plural:   "plugins",
-			aliases:  []string{"plug", "plugs", "plgn", "plgns"},
-			listView: true,
+			name:    "plugin",
+			plural:  "plugins",
+			aliases: []string{"plug", "plugs", "plgn", "plgns"},
 		},
 		items: items,
 	}
@@ -65,12 +64,12 @@ func (p *Plugins) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (p *Plugins) JSON(w io.Writer) error {
-	return displayJSON(w, p.items, p.resource.listView)
+	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *Plugins) YAML(w io.Writer) error {
-	return displayYAML(w, p.items, p.resource.listView)
+	return displayYAML(w, p.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/plugins.go
+++ b/resource/plugins.go
@@ -63,12 +63,20 @@ func (p *Plugins) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (p *Plugins) JSON(w io.Writer) error {
+func (p *Plugins) JSON(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayJSON(w, p.items[0])
+	}
+
 	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (p *Plugins) YAML(w io.Writer) error {
+func (p *Plugins) YAML(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayYAML(w, p.items[0])
+	}
+
 	return displayYAML(w, p.items)
 }
 

--- a/resource/plugins_test.go
+++ b/resource/plugins_test.go
@@ -28,15 +28,6 @@ var (
 			CreatedAt:      &plugTime,
 		},
 	}
-	plugsSingle = []types.Plugin{
-		{
-			ID:             types.UUID("1234"),
-			Type:           strptr("logs"),
-			Implementation: strptr("kubernetes"),
-			Version:        strptr("v1.0.0"),
-			CreatedAt:      &plugTime,
-		},
-	}
 )
 
 func TestNewPlugins(t *testing.T) {
@@ -49,13 +40,6 @@ func TestNewPlugins(t *testing.T) {
 
 	a = Plugin()
 	assert.NotNil(t, a)
-}
-
-func TestPluginsDisableListView(t *testing.T) {
-	a := NewPlugins(plugsSingle)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestPluginsTable(t *testing.T) {
@@ -72,24 +56,4 @@ func TestPluginsTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(plugs), info.numRows)
-}
-
-func TestPluginsJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewPlugins(plugsSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestPluginsYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewPlugins(plugsSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
 }

--- a/resource/plugins_test.go
+++ b/resource/plugins_test.go
@@ -28,7 +28,37 @@ var (
 			CreatedAt:      &plugTime,
 		},
 	}
+
+	plugsSingle = []types.Plugin{
+		{
+			ID:             types.UUID("1234"),
+			Type:           strptr("logs"),
+			Implementation: strptr("kubernetes"),
+			Version:        strptr("v1.0.0"),
+			CreatedAt:      &plugTime,
+		},
+	}
 )
+
+func TestPluginsJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewPlugins(plugsSingle)
+	err := a.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = a.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestPluginsYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewPlugins(plugsSingle)
+	err := a.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = a.YAML(buf, false)
+	assert.Nil(t, err)
+}
 
 func TestNewPlugins(t *testing.T) {
 	a := NewPlugins(nil)

--- a/resource/providers.go
+++ b/resource/providers.go
@@ -59,12 +59,20 @@ func (c *Providers) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (c *Providers) JSON(w io.Writer) error {
+func (c *Providers) JSON(w io.Writer, listView bool) error {
+	if !listView && len(c.items) == 1 {
+		return displayJSON(w, c.items[0])
+	}
+
 	return displayJSON(w, c.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (c *Providers) YAML(w io.Writer) error {
+func (c *Providers) YAML(w io.Writer, listView bool) error {
+	if !listView && len(c.items) == 1 {
+		return displayYAML(w, c.items[0])
+	}
+
 	return displayYAML(w, c.items)
 }
 

--- a/resource/providers.go
+++ b/resource/providers.go
@@ -18,9 +18,8 @@ type Providers struct {
 func NewProviders(items []types.Provider) *Providers {
 	return &Providers{
 		resource: resource{
-			name:     "provider",
-			plural:   "providers",
-			listView: true,
+			name:   "provider",
+			plural: "providers",
 		},
 		items: items,
 	}
@@ -61,12 +60,12 @@ func (c *Providers) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (c *Providers) JSON(w io.Writer) error {
-	return displayJSON(w, c.items, c.resource.listView)
+	return displayJSON(w, c.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (c *Providers) YAML(w io.Writer) error {
-	return displayYAML(w, c.items, c.resource.listView)
+	return displayYAML(w, c.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/providers_test.go
+++ b/resource/providers_test.go
@@ -26,14 +26,6 @@ var (
 			CreatedAt:   &providerTime,
 		},
 	}
-	providersSingle = []types.Provider{
-		{
-			ID:          types.UUID("1234"),
-			Provider:    strptr("google"),
-			Description: strptr("google description"),
-			CreatedAt:   &providerTime,
-		},
-	}
 )
 
 func TestNewProviders(t *testing.T) {
@@ -46,13 +38,6 @@ func TestNewProviders(t *testing.T) {
 
 	a = Provider()
 	assert.NotNil(t, a)
-}
-
-func TestProvidersDisableListView(t *testing.T) {
-	a := NewProviders(providersSingle)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestProvidersTable(t *testing.T) {
@@ -69,24 +54,4 @@ func TestProvidersTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(providers), info.numRows)
-}
-
-func TestProvidersJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewProviders(providersSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestProvidersYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewProviders(providersSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
 }

--- a/resource/providers_test.go
+++ b/resource/providers_test.go
@@ -26,7 +26,36 @@ var (
 			CreatedAt:   &providerTime,
 		},
 	}
+
+	providersSingle = []types.Provider{
+		{
+			ID:          types.UUID("1234"),
+			Provider:    strptr("google"),
+			Description: strptr("google description"),
+			CreatedAt:   &providerTime,
+		},
+	}
 )
+
+func TestProvidersJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewProviders(providersSingle)
+	err := a.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = a.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestProvidersYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewProviders(providersSingle)
+	err := a.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = a.YAML(buf, false)
+	assert.Nil(t, err)
+}
 
 func TestNewProviders(t *testing.T) {
 	a := NewProviders(nil)

--- a/resource/registries.go
+++ b/resource/registries.go
@@ -19,10 +19,9 @@ type Registries struct {
 func NewRegistries(items []types.Registry) *Registries {
 	return &Registries{
 		resource: resource{
-			name:     "registry",
-			plural:   "registries",
-			aliases:  []string{"reg", "regs"},
-			listView: true,
+			name:    "registry",
+			plural:  "registries",
+			aliases: []string{"reg", "regs"},
 		},
 		items: items,
 	}
@@ -65,12 +64,12 @@ func (p *Registries) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (p *Registries) JSON(w io.Writer) error {
-	return displayJSON(w, p.items, p.resource.listView)
+	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (p *Registries) YAML(w io.Writer) error {
-	return displayYAML(w, p.items, p.resource.listView)
+	return displayYAML(w, p.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/registries.go
+++ b/resource/registries.go
@@ -63,12 +63,20 @@ func (p *Registries) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (p *Registries) JSON(w io.Writer) error {
+func (p *Registries) JSON(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayJSON(w, p.items[0])
+	}
+
 	return displayJSON(w, p.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (p *Registries) YAML(w io.Writer) error {
+func (p *Registries) YAML(w io.Writer, listView bool) error {
+	if !listView && len(p.items) == 1 {
+		return displayYAML(w, p.items[0])
+	}
+
 	return displayYAML(w, p.items)
 }
 

--- a/resource/registries_test.go
+++ b/resource/registries_test.go
@@ -28,15 +28,6 @@ var (
 			Serveraddress: strptr("2.0.0"),
 		},
 	}
-	regsSingle = []types.Registry{
-		{
-			ID:            types.UUID("1234"),
-			CreatedAt:     &regTime,
-			Description:   strptr("logs"),
-			Provider:      strptr("kubernetes"),
-			Serveraddress: strptr("v1.0.0"),
-		},
-	}
 )
 
 func TestNewRegistries(t *testing.T) {
@@ -51,12 +42,6 @@ func TestNewRegistries(t *testing.T) {
 	assert.NotNil(t, a)
 }
 
-func TestRegistriesDisableListView(t *testing.T) {
-	a := NewRegistries(regsSingle)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
-}
 func TestRegistriesTable(t *testing.T) {
 	buf := new(bytes.Buffer)
 
@@ -71,24 +56,4 @@ func TestRegistriesTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(regs), info.numRows)
-}
-
-func TestRegistriesJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewRegistries(regsSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestRegistriesYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewRegistries(regsSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
 }

--- a/resource/registries_test.go
+++ b/resource/registries_test.go
@@ -28,7 +28,37 @@ var (
 			Serveraddress: strptr("2.0.0"),
 		},
 	}
+
+	regsSingle = []types.Registry{
+		{
+			ID:            types.UUID("1234"),
+			CreatedAt:     &regTime,
+			Description:   strptr("logs"),
+			Provider:      strptr("kubernetes"),
+			Serveraddress: strptr("v1.0.0"),
+		},
+	}
 )
+
+func TestRegistriesJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewRegistries(regsSingle)
+	err := a.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = a.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestRegistriesYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	a := NewRegistries(regsSingle)
+	err := a.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = a.YAML(buf, false)
+	assert.Nil(t, err)
+}
 
 func TestNewRegistries(t *testing.T) {
 	a := NewRegistries(nil)

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -11,16 +11,14 @@ type resourceInterface interface {
 	Plural() string
 	Aliases() []string
 	HasAlias(name string) bool
-	DisableListView()
 }
 
 type resource struct {
 	resourceInterface
 
-	name     string
-	plural   string
-	aliases  []string
-	listView bool
+	name    string
+	plural  string
+	aliases []string
 }
 
 func (r *resource) Name() string {
@@ -37,8 +35,4 @@ func (r *resource) Aliases() []string {
 	}
 
 	return r.aliases
-}
-
-func (r *resource) DisableListView() {
-	r.listView = false
 }

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -42,13 +42,3 @@ func TestAliases(t *testing.T) {
 	r.plural = "plugins"
 	assert.Equal(t, r.Aliases(), []string{r.plural}, "plural only")
 }
-
-func TestDisableListView(t *testing.T) {
-	r := resource{
-		name:     "plugin",
-		plural:   "plugins",
-		listView: true,
-	}
-	r.DisableListView()
-	assert.Equal(t, r.listView, false)
-}

--- a/resource/templates.go
+++ b/resource/templates.go
@@ -83,12 +83,20 @@ func (c *Templates) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (c *Templates) JSON(w io.Writer) error {
+func (c *Templates) JSON(w io.Writer, listView bool) error {
+	if !listView && len(c.items) == 1 {
+		return displayJSON(w, c.items[0])
+	}
+
 	return displayJSON(w, c.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (c *Templates) YAML(w io.Writer) error {
+func (c *Templates) YAML(w io.Writer, listView bool) error {
+	if !listView && len(c.items) == 1 {
+		return displayYAML(w, c.items[0])
+	}
+
 	return displayYAML(w, c.items)
 }
 

--- a/resource/templates.go
+++ b/resource/templates.go
@@ -27,10 +27,9 @@ type filterFunc func(types.Template) bool
 func NewTemplates(items []types.Template) *Templates {
 	return &Templates{
 		resource: resource{
-			name:     "template",
-			plural:   "templates",
-			aliases:  []string{"tmpl", "tmpls"},
-			listView: true,
+			name:    "template",
+			plural:  "templates",
+			aliases: []string{"tmpl", "tmpls"},
 		},
 		items: items,
 	}
@@ -85,12 +84,12 @@ func (c *Templates) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (c *Templates) JSON(w io.Writer) error {
-	return displayJSON(w, c.items, c.resource.listView)
+	return displayJSON(w, c.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (c *Templates) YAML(w io.Writer) error {
-	return displayYAML(w, c.items, c.resource.listView)
+	return displayYAML(w, c.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/templates_test.go
+++ b/resource/templates_test.go
@@ -55,9 +55,6 @@ var (
 			Configuration: &tmplConfig,
 		},
 	}
-	tmplSingle = []types.Template{
-		tmplGood,
-	}
 )
 
 func TestNewTemplates(t *testing.T) {
@@ -70,13 +67,6 @@ func TestNewTemplates(t *testing.T) {
 
 	a = Template()
 	assert.NotNil(t, a)
-}
-
-func TestTemplatesDisableListView(t *testing.T) {
-	a := NewTemplates(nil)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestTemplatesTable(t *testing.T) {
@@ -171,24 +161,4 @@ func TestGetMasterKubernetesVersion(t *testing.T) {
 	v, err = getMasterKubernetesVersion(&tmplGood)
 	assert.Nil(t, err)
 	assert.Equal(t, v, tmplK8sVersion)
-}
-
-func TestTemplatesJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	templs := NewTemplates(tmplSingle)
-	err := templs.JSON(buf)
-	assert.Nil(t, err)
-	templs.DisableListView()
-	err = templs.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestTemplatesYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	templs := NewTemplates(tmplSingle)
-	err := templs.YAML(buf)
-	assert.Nil(t, err)
-	templs.DisableListView()
-	err = templs.YAML(buf)
-	assert.Nil(t, err)
 }

--- a/resource/templates_test.go
+++ b/resource/templates_test.go
@@ -55,7 +55,31 @@ var (
 			Configuration: &tmplConfig,
 		},
 	}
+
+	tmplSingle = []types.Template{
+		tmplGood,
+	}
 )
+
+func TestTemplatesJSON(t *testing.T) {
+	buf := new(bytes.Buffer)
+	templs := NewTemplates(tmplSingle)
+	err := templs.JSON(buf, true)
+	assert.Nil(t, err)
+
+	err = templs.JSON(buf, false)
+	assert.Nil(t, err)
+}
+
+func TestTemplatesYAML(t *testing.T) {
+	buf := new(bytes.Buffer)
+	templs := NewTemplates(tmplSingle)
+	err := templs.YAML(buf, true)
+	assert.Nil(t, err)
+
+	err = templs.YAML(buf, false)
+	assert.Nil(t, err)
+}
 
 func TestNewTemplates(t *testing.T) {
 	a := NewTemplates(nil)

--- a/resource/users.go
+++ b/resource/users.go
@@ -61,12 +61,12 @@ func (c *Users) Table(w io.Writer) error {
 }
 
 // JSON outputs the JSON representation to the given writer
-func (c *Users) JSON(w io.Writer) error {
+func (c *Users) JSON(w io.Writer, _ bool) error {
 	return displayJSON(w, c.items)
 }
 
 // YAML outputs the YAML representation to the given writer
-func (c *Users) YAML(w io.Writer) error {
+func (c *Users) YAML(w io.Writer, _ bool) error {
 	return displayYAML(w, c.items)
 }
 

--- a/resource/users.go
+++ b/resource/users.go
@@ -19,10 +19,9 @@ type Users struct {
 func NewUsers(items []types.User) *Users {
 	return &Users{
 		resource: resource{
-			name:     "user",
-			plural:   "users",
-			aliases:  []string{"usr", "usrs"},
-			listView: true,
+			name:    "user",
+			plural:  "users",
+			aliases: []string{"usr", "usrs"},
 		},
 		items: items,
 	}
@@ -63,12 +62,12 @@ func (c *Users) Table(w io.Writer) error {
 
 // JSON outputs the JSON representation to the given writer
 func (c *Users) JSON(w io.Writer) error {
-	return displayJSON(w, c.items, c.resource.listView)
+	return displayJSON(w, c.items)
 }
 
 // YAML outputs the YAML representation to the given writer
 func (c *Users) YAML(w io.Writer) error {
-	return displayYAML(w, c.items, c.resource.listView)
+	return displayYAML(w, c.items)
 }
 
 // JSONPath outputs the executed JSONPath template to the given writer

--- a/resource/users_test.go
+++ b/resource/users_test.go
@@ -26,14 +26,6 @@ var (
 			AddedAt: &userTime,
 		},
 	}
-	usersSingle = []types.User{
-		{
-			ID:      types.UUID("1234"),
-			Name:    strptr("Yugo H"),
-			Email:   strptr("y@containership.io"),
-			AddedAt: &userTime,
-		},
-	}
 )
 
 func TestNewUsers(t *testing.T) {
@@ -46,13 +38,6 @@ func TestNewUsers(t *testing.T) {
 
 	a = User()
 	assert.NotNil(t, a)
-}
-
-func TestUsersDisableListView(t *testing.T) {
-	a := NewUsers(usersSingle)
-	assert.NotNil(t, a)
-	a.resource.DisableListView()
-	assert.Equal(t, a.resource.listView, false)
 }
 
 func TestUsersTable(t *testing.T) {
@@ -69,24 +54,4 @@ func TestUsersTable(t *testing.T) {
 	assert.Equal(t, len(a.columns()), info.numHeaderCols)
 	assert.Equal(t, len(a.columns()), info.numCols)
 	assert.Equal(t, len(users), info.numRows)
-}
-
-func TestUsersJSON(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewUsers(usersSingle)
-	err := a.JSON(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.JSON(buf)
-	assert.Nil(t, err)
-}
-
-func TestUsersYAML(t *testing.T) {
-	buf := new(bytes.Buffer)
-	a := NewUsers(usersSingle)
-	err := a.YAML(buf)
-	assert.Nil(t, err)
-	a.resource.DisableListView()
-	err = a.YAML(buf)
-	assert.Nil(t, err)
 }


### PR DESCRIPTION
 ### Description

This reverts the previous commit that tried to solve the problem of out putting an array when only a single element is meant to be returned. 

It then adds the functional that when a single element is requested an object is returned when output is json, and a dictionary when output is yaml.

 #### What does this pull request accomplish?

 #### What issue(s) does this fix?
* Fixes #115 

 #### Additional Considerations

 ### Testing
`$ csctl get registry -o json`
```
[
  {
    "created_at": "1549463571373",
    "description": "ashleys",
    "id": "f7d50686-9268-4244-a035-02e5cf4871cd",
    "organization_id": "99f796e3-9a12-4b5c-affd-92870043d54a",
    "provider": "dockerhub",
    "serveraddress": "docker.io",
    "updated_at": "1549463571373"
  }
]
```

`$ csctl get registry f7d50686-9268-4244-a035-02e5cf4871cd -o json`
```
{
  "created_at": "1549463571373",
  "description": "ashleys",
  "id": "f7d50686-9268-4244-a035-02e5cf4871cd",
  "organization_id": "99f796e3-9a12-4b5c-affd-92870043d54a",
  "provider": "dockerhub",
  "serveraddress": "docker.io",
  "updated_at": "1549463571373"
}
```

`$ csctl get registry -o yaml`
```
- created_at: "1549463571373"
  description: ashleys
  id: f7d50686-9268-4244-a035-02e5cf4871cd
  organization_id: 99f796e3-9a12-4b5c-affd-92870043d54a
  provider: dockerhub
  serveraddress: docker.io
  updated_at: "1549463571373"
```

`$ csctl get registry f7d50686-9268-4244-a035-02e5cf4871cd -o yaml`
```
created_at: "1549463571373"
description: ashleys
id: f7d50686-9268-4244-a035-02e5cf4871cd
organization_id: 99f796e3-9a12-4b5c-affd-92870043d54a
provider: dockerhub
serveraddress: docker.io
updated_at: "1549463571373"
```


 #### Setup

`make install`

 #### Instructions

 ### Dependencies
