### PR TITLE
Add owner-id flag

### DIFF
--- a/cmd/get_cluster.go
+++ b/cmd/get_cluster.go
@@ -34,13 +34,8 @@ var getClusterCmd = &cobra.Command{
 
 		clusters := resource.NewCKEClusters(resp)
 
-		if mineOnly {
-			me, err := getMyAccountID()
-			if err != nil {
-				return err
-			}
-
-			clusters.FilterByOwnerID(me)
+		if ownerID != "" {
+			clusters.FilterByOwnerID(ownerID)
 		}
 
 		outputResponse(clusters, len(args) != 1)

--- a/cmd/get_cluster_rbac.go
+++ b/cmd/get_cluster_rbac.go
@@ -24,13 +24,8 @@ var getClusterRBACCmd = &cobra.Command{
 
 		roles := resource.NewAuthorizationRoles(resp)
 
-		if mineOnly {
-			me, err := getMyAccountID()
-			if err != nil {
-				return err
-			}
-
-			roles.FilterByOwnerID(me)
+		if ownerID != "" {
+			roles.FilterByOwnerID(ownerID)
 		}
 
 		outputResponse(roles, len(args) != 1)

--- a/cmd/get_organization.go
+++ b/cmd/get_organization.go
@@ -32,13 +32,8 @@ var getOrganizationCmd = &cobra.Command{
 
 		orgs := resource.NewOrganizations(resp)
 
-		if mineOnly {
-			me, err := getMyAccountID()
-			if err != nil {
-				return err
-			}
-
-			orgs.FilterByOwnerID(me)
+		if ownerID != "" {
+			orgs.FilterByOwnerID(ownerID)
 		}
 
 		outputResponse(orgs, len(args) != 1)

--- a/cmd/get_role.go
+++ b/cmd/get_role.go
@@ -34,13 +34,8 @@ var getRoleCmd = &cobra.Command{
 
 		roles := resource.NewAuthorizationRoles(resp)
 
-		if mineOnly {
-			me, err := getMyAccountID()
-			if err != nil {
-				return err
-			}
-
-			roles.FilterByOwnerID(me)
+		if ownerID != "" {
+			roles.FilterByOwnerID(ownerID)
 		}
 
 		outputResponse(roles, len(args) != 1)

--- a/cmd/get_role_binding.go
+++ b/cmd/get_role_binding.go
@@ -41,13 +41,8 @@ var getRoleBindingCmd = &cobra.Command{
 
 		roles := resource.NewAuthorizationRoleBindings(resp)
 
-		if mineOnly {
-			me, err := getMyAccountID()
-			if err != nil {
-				return err
-			}
-
-			roles.FilterByOwnerID(me)
+		if ownerID != "" {
+			roles.FilterByOwnerID(ownerID)
 		}
 
 		outputResponse(roles, len(args) != 1)

--- a/cmd/get_rule.go
+++ b/cmd/get_rule.go
@@ -41,13 +41,8 @@ var getRuleCmd = &cobra.Command{
 
 		roles := resource.NewAuthorizationRules(resp)
 
-		if mineOnly {
-			me, err := getMyAccountID()
-			if err != nil {
-				return err
-			}
-
-			roles.FilterByOwnerID(me)
+		if ownerID != "" {
+			roles.FilterByOwnerID(ownerID)
 		}
 
 		outputResponse(roles, len(args) != 1)

--- a/cmd/get_template.go
+++ b/cmd/get_template.go
@@ -34,13 +34,8 @@ var getTemplateCmd = &cobra.Command{
 
 		templates := resource.NewTemplates(resp)
 
-		if mineOnly {
-			me, err := getMyAccountID()
-			if err != nil {
-				return err
-			}
-
-			templates.FilterByOwnerID(me)
+		if ownerID != "" {
+			templates.FilterByOwnerID(ownerID)
 		}
 
 		// Non-CKE is deprecated. TODO consider filtering even earlier


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
* Adds `--owner-id` as an option for all relevant `get` requests. 
* Refactors `--mine` to fetch `account-id` and assign to `owner-id` field during the `persistentPreRunE` function of all `get` commands

 #### What issue(s) does this fix?
* n/a

 ### Testing
```
csctl get templates --owner-id=576eb5eb-26df-47af-8abc-f4effcd59ec1
csctl get templates --mine
```
