### PR TITLE
Add --plugin-audit-logs flag

### DIFF
--- a/cmd/create_cluster.go
+++ b/cmd/create_cluster.go
@@ -119,4 +119,6 @@ func init() {
 		"Cluster Management plugin (implementation must be \"containership\")")
 	createClusterCmd.PersistentFlags().StringVar(&createClusterOpts.PluginAutoscalerFlag.Val, "plugin-autoscaler", "",
 		"autoscaler plugin")
+	createClusterCmd.PersistentFlags().StringVar(&createClusterOpts.PluginAuditLogsFlag.Val, "plugin-audit-logs", "",
+		fmt.Sprintf("audit logs plugin (specify %q to disable)", plugin.NoImplementation))
 }


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
Allows you to pass `--plugin-audit-log` flag when creating clusters to manipulate the plugin version and implementation

 #### What issue(s) does this fix?
* n/a
