### PR TITLE
Fix incorrect logic for token defaults

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,12 +82,11 @@ func nodePoolScopedPreRunE(cmd *cobra.Command, _ []string) error {
 }
 
 func clientsetRequiredPreRunE(cmd *cobra.Command, _ []string) error {
-	if userToken != "" {
-		// Command line flag was set and it takes precedence
-		return nil
+	// Only pull token from config if was not set by --token flag
+	if userToken == "" {
+		userToken = viper.GetString("token")
 	}
 
-	userToken = viper.GetString("token")
 	if userToken == "" {
 		return errors.New("please specify a token via --token or config file")
 	}


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
The logic for the prerun function was incorrect in eagerly returning vs just ignoring the configuration token and continuing on

 #### What issue(s) does this fix?
* Bug related to passing `--token` flag

 #### Additional Considerations
TODO: add regression test

 ### Testing
Passing `--token` flag should work correctly

 #### Setup
n/a

 #### Instructions
n/a

 ### Dependencies
n/a
